### PR TITLE
remove the need for space between number and units

### DIFF
--- a/lib/ruby_units/unit.rb
+++ b/lib/ruby_units/unit.rb
@@ -1250,7 +1250,7 @@ class Unit < Numeric
     rational = %r{[+-]?\d+\/\d+}
     # complex numbers... -1.2+3i, +1.2-3.3i
     complex = %r{#{sci}{2,2}i}
-    anynumber = %r{(?:(#{complex}|#{rational}|#{sci})\b)?\s?([\D].*)?}
+    anynumber = %r{(#{complex}|#{rational}|#{sci})?\s?([\D].*)?}
     num, unit = string.scan(anynumber).first
     [case num
       when NilClass

--- a/spec/ruby-units/unit_spec.rb
+++ b/spec/ruby-units/unit_spec.rb
@@ -107,6 +107,36 @@ describe "Create some simple units" do
     its(:base) {should == Unit("0.001 m")}
   end
 
+  describe Unit("1g") do
+    it {should be_a Numeric}
+    it {should be_an_instance_of Unit}
+    its(:scalar) {should == 1}
+    its(:scalar) {should be_an Integer}
+    its(:units) {should == "g"}
+    its(:kind) {should == :mass}
+    it {should_not be_temperature}
+    it {should_not be_degree}
+    it {should_not be_base}
+    it {should_not be_unitless}
+    it {should_not be_zero}
+    its(:base) {should == subject}
+  end
+  
+  describe Unit("1.4g") do
+    it {should be_a Numeric}
+    it {should be_an_instance_of Unit}
+    its(:scalar) {should === 1.4}
+    its(:scalar) {should be_a Float}
+    its(:units) {should == "g"}
+    its(:kind) {should == :mass}
+    it {should_not be_temperature}
+    it {should_not be_degree}
+    it {should_not be_base}
+    it {should_not be_unitless}
+    it {should_not be_zero}
+    its(:base) {should == subject}  
+  end
+
   describe Unit("10 m/s^2") do
     it {should be_an_instance_of Unit}
     its(:scalar) {should == 10}


### PR DESCRIPTION
Remove the need for space between number and units, otherwise things like Unit.new("1.4g") throw a stack level too deep error.  The requirement seems overly restrictive for no real gain that I can determine
