### PR TITLE
fix bug where "Unit.new('3 mg') == nil" raises exception

### DIFF
--- a/lib/ruby_units/unit.rb
+++ b/lib/ruby_units/unit.rb
@@ -488,8 +488,12 @@ class Unit < Numeric
       return false unless self =~ other
       return self.base_scalar == other.base_scalar
     else
-      x,y = coerce(other)
-      return x == y
+      begin
+        x,y = coerce(other)
+        return x == y
+      rescue ArgumentError
+        return false     # before the addition of this rescue, "Unit.new(3, 'g') == nil" would raise an exception (but .nil? worked fine)
+      end
     end      
   end
   

--- a/test/test_ruby-units.rb
+++ b/test/test_ruby-units.rb
@@ -569,6 +569,16 @@ class TestRubyUnits < Test::Unit::TestCase
     unit2 = Unit.new("10 mm")
     assert unit1 == unit2
   end
+
+  def test_inequality_with_unit
+    unit1 = Unit.new("1 cm")
+    unit2 = Unit.new("1 mm")
+    assert unit1 != unit2
+  end
+
+  def test_inequality_with_uncoercible_object
+    assert Unit.new("1 cm") != nil
+  end
   
   def test_temperature_conversions
     assert_raises(ArgumentError) { '-1 tempK'.unit}


### PR DESCRIPTION
When using == to compare a Unit with something that isn't coercible into a Unit (nil, "foo", etc.), an ArgumentError exception is raised saying either "Unit not recognized" (for strings that aren't a valid unit) or "Invalid Unit Format".  It's more typical to be able to compare things of different datatypes and just get false back instead of having an exception be raised (e.g. `3 == Kernel`).
