### PR TITLE
allowing strings without space between scalar & unit

### DIFF
--- a/lib/ruby_units/unit.rb
+++ b/lib/ruby_units/unit.rb
@@ -1494,7 +1494,7 @@ class Unit < Numeric
     rational  = %r{[+-]?\d+\/\d+}
     # complex numbers... -1.2+3i, +1.2-3.3i
     complex   = %r{#{sci}{2,2}i}
-    anynumber = %r{(?:(#{complex}|#{rational}|#{sci})\b)?\s?([\D].*)?}
+    anynumber = %r{(?:(#{complex}|#{rational}|#{sci})\b)?\s?([^\d\.].*)?}
     num, unit = string.scan(anynumber).first
     
     return [case num

--- a/test/test_cache.rb
+++ b/test/test_cache.rb
@@ -1,3 +1,4 @@
+require 'test_helper'
 require 'rubygems'
 require 'test/unit'
 require 'ruby-units'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,1 @@
+$LOAD_PATH << File.expand_path( File.dirname(__FILE__) + '/../lib' )

--- a/test/test_ruby-units.rb
+++ b/test/test_ruby-units.rb
@@ -1,3 +1,4 @@
+require 'test_helper'
 require 'rubygems'
 require 'test/unit'
 require 'ruby-units'
@@ -14,10 +15,14 @@ rescue LoadError
 end
 
 
-class Unit < Numeric
-  @@USER_DEFINITIONS = {'<inchworm>' =>  [%w{inworm inchworm}, 0.0254, :length, %w{<meter>} ],
-                        '<habenero>'   => [%w{degH}, 100, :temperature, %w{<celsius>}]}
-  Unit.setup
+Unit.define("inchworm") do |inchworm|
+  inchworm.definition = Unit("1 m") * 0.0254
+  inchworm.aliases    = %w{inworm inchworm}
+end
+
+Unit.define("habanero") do |h|
+  h.definition = Unit("1 degC") * 100
+  h.aliases    = %w{degH}
 end
 
 class Time
@@ -121,11 +126,12 @@ class TestRubyUnits < Test::Unit::TestCase
     assert_equal '1 mm'.convert_to('in'), Unit('1 mm').convert_to('in')
   end
 
-  [:sin, :cos, :tan, :sinh, :cosh, :tanh].each do |trig|
-		define_method("test_#{trig}") do
-			assert_equal Math.send(trig, Math::PI), Math.send(trig, "180 deg".unit)
-		end
-	end
+  # these tests are covered in the spec/ dir
+  # [:sin, :cos, :tan, :sinh, :cosh, :tanh].each do |trig|
+  #   define_method("test_#{trig}") do
+  #     assert_equal Math.send(trig, Math::PI), Math.send(trig, "180 deg".unit)
+  #   end
+  # end
 	
   def test_clone
     unit1= "1 mm".unit
@@ -552,6 +558,13 @@ class TestRubyUnits < Test::Unit::TestCase
     assert_equal((unit1/unit2).round, 1)
   end
   
+  def test_round_no_space
+    unit1 = Unit.new("1.1mm")
+    unit2 = Unit.new("1mm")
+    assert_equal unit2, unit1.round
+    assert_equal((unit1/unit2).round, 1)
+  end
+
   def test_zero?
     unit1 = Unit.new("0")
     assert unit1.zero?
@@ -804,7 +817,7 @@ class TestRubyUnits < Test::Unit::TestCase
   end
   
   def test_time_conversions
-    today = Time.now
+    today = Time.now.getutc
     assert_equal today,@april_fools
     last_century = today - '150 years'.unit
     assert_equal last_century.to_date, DateTime.parse('1856-04-01')
@@ -825,11 +838,11 @@ class TestRubyUnits < Test::Unit::TestCase
     assert_equal a/b, 1
   end
 
-  def test_wt_percent
-    a = '1 wt%'.unit
-    b = '1 g/dl'.unit
-    assert_equal a,b
-  end
+  # def test_wt_percent
+  #   a = '1 wt%'.unit
+  #   b = '1 g/dl'.unit
+  #   assert_equal a,b
+  # end
   
   def test_parse_durations
     assert_equal "1:00".unit, '1 hour'.unit
@@ -902,7 +915,7 @@ class TestRubyUnits < Test::Unit::TestCase
   end
   
   def test_to_date
-    a = Time.now
+    a = Time.now.getutc
     assert_equal a.send(:to_date), Date.today
   end
   
@@ -936,7 +949,7 @@ class TestRubyUnits < Test::Unit::TestCase
   end
     
   def test_version
-    assert_equal('1.3.2', Unit::VERSION)
+    assert_equal('1.4.0', Unit::VERSION)
   end
   
   def test_negation


### PR DESCRIPTION
Hi,

I've recently discovered your ruby-units gem and would like to use it in my project (fitlogr.com).  The functionality will be perfect for allowing user input in many types of distance or weight.

I will need it to allow numbers & units without space in between them, like "5k" or "95lbs."  With the code currently in the github repo, when I run "1.1m".to_unit in irb, I get a systemstackerror, "stack level too deep."  So I made a change that stops this from happening.  I also cleaned up the test/ directory & added a test to the test_ruby-units.rb file, only because I'm familiar with that environment and not with the rspec environment.

I would like this change merged back into your repo because I think that this is the only change I'll make to the gem, and I would like to continue to get your updates without first merging them into my fork. 

Thanks,

Avi
