### PR TITLE
Remove implicit timezone from time specs

### DIFF
--- a/spec/ruby-units/time_spec.rb
+++ b/spec/ruby-units/time_spec.rb
@@ -8,15 +8,15 @@ describe Time do
 
   context ".at" do
     subject { Date.new(2011,4,1).to_unit }
-    specify { Time.at(subject - Date.new(1970,1,1)).strftime("%D %T").should == "03/31/11 20:00:00"}
+    specify { Time.at(subject - Date.new(1970,1,1)).getutc.strftime("%D %T").should == "04/01/11 00:00:00"}
     specify { Time.at(subject - Date.new(1970,1,1), 500).usec.should == 500}
   end
-  
+
   context ".in" do
     specify { Time.in("5 min").should be_a Time}
     specify { Time.in("5 min").should > Time.now}
   end
-  
+
   context '#to_unit' do
     subject { now }
     its(:to_unit)         { should be_an_instance_of(Unit) }
@@ -24,7 +24,7 @@ describe Time do
     specify               { subject.to_unit('h').kind.should == :time}
     specify               { subject.to_unit('h').units.should == 'h'}
   end
-  
+
   context 'addition (+)' do
     specify { (Time.now + 1).should == Time.at(1303656390 + 1)}
     specify { (Time.now + Unit("10 min")).should == Time.at(1303656390 + 600)}


### PR DESCRIPTION
Hi Kevin!

I made a change to the spec to make them pass in any timezone, but forcing the time comparison to happen in UTC.
- Changed spec to add getutc to lock specced time to UTC
- Time.now automagically converts to_local; this means the test suite
  passes in olbrich's timezone but not in the other 23/24ths of the
  Earth ;-)
