### PR TITLE
Match Math.sqrt to default behaviour with Integers 

### DIFF
--- a/lib/ruby_units/math.rb
+++ b/lib/ruby_units/math.rb
@@ -7,10 +7,16 @@ module Math
   alias :unit_sqrt :sqrt
   # @return [Numeric]
   def sqrt(n)
-    if Unit === n
+    result = if Unit === n
       (n**(Rational(1,2))).to_unit 
     else
       unit_sqrt(n)
+    end
+    
+    if result.is_a?(Fixnum)
+      result.to_f
+    else
+      result
     end
   end
   # @return [Numeric]


### PR DESCRIPTION
I realise that the mathn library changes this, but I think most developers rely on Math.sqrt returning a float like the default math.rb library. As such when we use ruby-unit + other gems that rely on Math.sqrt returning a Float we can get issues (alchemist, or rgeo for example).