### PR TITLE
Fixed incorrect definition for the standard gravity

### DIFF
--- a/lib/ruby_units/unit_definitions/standard.rb
+++ b/lib/ruby_units/unit_definitions/standard.rb
@@ -278,7 +278,7 @@ end
 
 Unit.define('gee') do |gee|
   # approximated as a rational number to minimize round-off errors
-  gee.definition    = Unit(Rational(196131,20000), 'm/s^2') # equivalent to 9.80655 m/s^2
+  gee.definition    = Unit(Rational(196133,20000), 'm/s^2') # equivalent to 9.80665 m/s^2
   gee.aliases       = %w{gee standard-gravitation}
 end
 


### PR DESCRIPTION
Affects conversions of pressures
Source: http://en.wikipedia.org/wiki/Standard_gravity
