### PR TITLE
Remove non-existent RakeFile from gemspec

### DIFF
--- a/ruby-units.gemspec
+++ b/ruby-units.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
     "CHANGELOG.txt",
     "LICENSE.txt",
     "README.md",
-    "RakeFile",
+    "Rakefile.rb",
     "TODO",
     "VERSION",
     "lib/ruby-units.rb",


### PR DESCRIPTION
Prevents error / failure when deploying gem.
