### PR TITLE
provide method to get the best prefix

### DIFF
--- a/lib/ruby_units/unit.rb
+++ b/lib/ruby_units/unit.rb
@@ -1267,13 +1267,13 @@ module RubyUnits
     end
 
     # returns a new unit that has been
-    def natural
-      best_prefix =  if (self.kind == :information)
+    def best_prefix
+      _best_prefix =  if (self.kind == :information)
         @@PREFIX_VALUES.key(2**((Math.log(self.base_scalar,2) / 10.0).floor * 10))
       else
-        @@PREFIX_VALUES.key(10**((Math.log(self.base_scalar,10) / 3.0).floor * 3))
+        @@PREFIX_VALUES.key(10**((Math.log10(self.base_scalar) / 3.0).floor * 3))
       end
-      self.to(RubyUnits::Unit.new(@@PREFIX_MAP.key(best_prefix)+self.units(false)))
+      self.to(RubyUnits::Unit.new(@@PREFIX_MAP.key(_best_prefix)+self.units(false)))
     end
 
     # Protected and Private Functions that should only be called from this class

--- a/lib/ruby_units/unit_definitions/base.rb
+++ b/lib/ruby_units/unit_definitions/base.rb
@@ -61,7 +61,7 @@ RubyUnits::Unit.define("byte") do |unit|
   unit.scalar    = 1
   unit.numerator = %w{<byte>}
   unit.aliases   = %w{B byte bytes}
-  unit.kind      = :memory
+  unit.kind      = :information
 end
 
 RubyUnits::Unit.define("dollar") do |unit|

--- a/spec/ruby-units/unit_spec.rb
+++ b/spec/ruby-units/unit_spec.rb
@@ -1306,6 +1306,11 @@ describe "Unit Math" do
     specify { Unit('23 m').div(Unit('2 m')).should == 11 }
   end
 
+  context '#best_prefix' do
+    specify { Unit('1024 KiB').best_prefix.should == Unit('1 MiB')}
+    specify { Unit('1000 m').best_prefix.should == Unit('1 km')}
+  end
+
   context "Time helper functions" do
     before do
       Time.stub!(:now).and_return(Time.utc(2011,10,16))


### PR DESCRIPTION
Provide a method to rescale a unit to use the closest prefix.  Leaves the unit itself alone and will use prefixes that are multiples of 1024 for 'information' units (like bytes).
