### PR TITLE
Return base unit from #best_prefix if scalar is 0

### DIFF
--- a/lib/ruby_units/unit.rb
+++ b/lib/ruby_units/unit.rb
@@ -1266,8 +1266,9 @@ module RubyUnits
       end
     end
 
-    # returns a new unit that has been
+    # returns a new unit that has been scaled to be more in line with typical usage.
     def best_prefix
+      return self.to_base if self.scalar == 0
       _best_prefix =  if (self.kind == :information)
         @@PREFIX_VALUES.key(2**((Math.log(self.base_scalar,2) / 10.0).floor * 10))
       else

--- a/spec/ruby-units/unit_spec.rb
+++ b/spec/ruby-units/unit_spec.rb
@@ -1321,6 +1321,7 @@ describe "Unit Math" do
   context '#best_prefix' do
     specify { Unit('1024 KiB').best_prefix.should == Unit('1 MiB')}
     specify { Unit('1000 m').best_prefix.should == Unit('1 km')}
+    specify { expect { Unit('0 m').best_prefix }.to_not raise_error }
   end
 
   context "Time helper functions" do


### PR DESCRIPTION
Without this, #best_prefix will raise FloatDomainError while trying to
call #floor on '-Infinity' if the scalar is 0.
