### PR TITLE
Test for zero? before using to fix Unit <=> string comparisons

### DIFF
--- a/lib/ruby_units/unit.rb
+++ b/lib/ruby_units/unit.rb
@@ -617,7 +617,7 @@ module RubyUnits
           return self.base_scalar <=> other.base_scalar
         else
           x, y = coerce(other)
-          return x <=> y
+          return y <=> x
       end
     end
 

--- a/spec/ruby-units/unit_spec.rb
+++ b/spec/ruby-units/unit_spec.rb
@@ -859,8 +859,8 @@ describe "Unit Comparisons" do
     end
 
     context "with coercions should be valid" do
-      specify { Unit("1GB") > "500MB" }
-      specify { Unit("0.5GB") < "900MB" }
+      specify { expect(Unit("1GB") > "500MB").to eq(true) }
+      specify { expect(Unit("0.5GB") < "900MB").to eq(true) }
     end
   end
   


### PR DESCRIPTION
Previously, comparisons such as the following would fail:

``` ruby
Unit('500MB') > "100MB"
```

This is because of a #zero? method call on the previous case, which isn't implemented on string for obvious reasons.  

Checking for it's existence with #respond_to? seemed an easy fix.
