### PR TITLE
Fix currency parsing stack limit too deep error

### DIFF
--- a/lib/ruby_units/unit.rb
+++ b/lib/ruby_units/unit.rb
@@ -1541,6 +1541,9 @@ module RubyUnits
     # @return [Array] consisting of [Numeric, "unit"]
     # @private
     def self.parse_into_numbers_and_units(string)
+      if string =~ /\$\s*(#{NUMBER_REGEX})/
+        string = "#{$1} USD"
+      end
       # scientific notation.... 123.234E22, -123.456e-10
       sci       = %r{[+-]?\d*[.]?\d+(?:[Ee][+-]?)?\d*}
       # rational numbers.... -1/3, 1/5, 20/100, -6 1/2, -6-1/2

--- a/spec/ruby-units/unit_spec.rb
+++ b/spec/ruby-units/unit_spec.rb
@@ -413,6 +413,22 @@ describe "Create some simple units" do
     it { subject.convert_to("in/s").should be_within(Unit("0.0001 in/s")).of(Unit("1.0043269330917 in/s")) }
   end
 
+  # dollars
+  describe Unit("$1.45") do
+    it { should be_an_instance_of Unit }
+    it { should == Unit("1 dollar") + Unit("45 cents") }
+    its(:scalar) { should be_a Numeric }
+    its(:units) { should == "USD" }
+    its(:kind) { should == :currency }
+    it { should_not be_temperature }
+    it { should_not be_degree }
+    it { should be_base }
+    it { should_not be_unitless }
+    it { should_not be_zero }
+    its(:base) { should be_a Numeric }
+    its(:temperature_scale) { should be_nil }
+  end
+
   # Farads
   describe Unit("1 F") do
     it { should be_an_instance_of Unit }


### PR DESCRIPTION
Attempting to parse Unit('$1.45') throws a 'stack limit reached' error.
- Fixed parse_into_numbers_and_units to account for leading '$'
- Added test for currency parsing
