### PR TITLE
Convert Rspecs to v. 3 syntax

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ group :test do
   gem 'rcov', :platforms => :mri_18
   gem 'simplecov', :require => false, :platforms => :mri_19
   gem 'simplecov-html', :platforms => :mri_19
-  gem 'rspec', '~>2.5'
+  gem 'rspec', '~> 3.0'
+  gem 'rspec-its', '~> 1.0'
 end
 

--- a/spec/ruby-units/array_spec.rb
+++ b/spec/ruby-units/array_spec.rb
@@ -4,11 +4,11 @@ describe Array do
   
   subject { [1, 'cm'] }
   
-  it {should be_kind_of Array}
-  it {should respond_to :to_unit}
+  it {is_expected.to be_kind_of Array}
+  it {is_expected.to respond_to :to_unit}
   
-  specify { subject.to_unit.should be_instance_of Unit}
-  specify { subject.to_unit.should == "1 cm".to_unit }
-  specify { subject.to_unit('mm').should == "10 mm".to_unit}
+  specify { expect(subject.to_unit).to be_instance_of Unit}
+  specify { expect(subject.to_unit).to eq("1 cm".to_unit) }
+  specify { expect(subject.to_unit('mm')).to eq("10 mm".to_unit)}
   
 end

--- a/spec/ruby-units/bugs_spec.rb
+++ b/spec/ruby-units/bugs_spec.rb
@@ -5,6 +5,6 @@ describe "Github issue #49" do
   let(:b) { Unit.new(a)}
 
   it "should subtract a unit properly from one initialized with a unit" do
-    (b - Unit("1.5 cm^3")).should == Unit("1.5 cm^3")
+    expect(b - Unit("1.5 cm^3")).to eq(Unit("1.5 cm^3"))
   end
 end

--- a/spec/ruby-units/cache_spec.rb
+++ b/spec/ruby-units/cache_spec.rb
@@ -12,20 +12,20 @@ describe Unit::Cache do
   context ".clear" do    
     it "should clear the cache" do
       subject.clear
-      subject.get('m').should be_nil
+      expect(subject.get('m')).to be_nil
     end
   end
 
   context ".get" do
     it "should retrieve values already in the cache" do
-      subject.get['m'].should == unit
+      expect(subject.get['m']).to eq(unit)
     end
   end
 
   context ".set" do
     it "should put a unit into the cache" do
       subject.set('kg', Unit('1 kg'))
-      subject.get['kg'].should == Unit('1 kg')
+      expect(subject.get['kg']).to eq(Unit('1 kg'))
     end
   end
 end

--- a/spec/ruby-units/complex_spec.rb
+++ b/spec/ruby-units/complex_spec.rb
@@ -6,23 +6,23 @@ require File.dirname(__FILE__) + '/../spec_helper'
 
 describe Complex do
   subject { Complex(1,1) }
-  it { should respond_to :to_unit }
+  it { is_expected.to respond_to :to_unit }
 end
 
 describe "Complex Unit" do
   subject { Complex(1.0, -1.0).to_unit }
   
-  it { should be_instance_of Unit}
-  it(:scalar) { should be_kind_of Complex }
+  it { is_expected.to be_instance_of Unit}
+  it(:scalar) { is_expected.to be_kind_of Complex }
 
-  it { should == "1-1i".to_unit }
-  it { should === "1-1i".to_unit }
+  it { is_expected.to eq("1-1i".to_unit) }
+  it { is_expected.to be === "1-1i".to_unit }
 
   if RUBY_VERSION < "1.9"
     context "in Ruby < 1.9" do
       it "is comparable" do
-        subject.should > "1+0.5i".to_unit
-        subject.should < "2+1i".to_unit
+        expect(subject).to be > "1+0.5i".to_unit
+        expect(subject).to be < "2+1i".to_unit
       end
     end
   else

--- a/spec/ruby-units/date_spec.rb
+++ b/spec/ruby-units/date_spec.rb
@@ -3,36 +3,36 @@ require File.dirname(__FILE__) + '/../spec_helper'
 describe Date do
   subject { Date.new(2011,4,1) }
   
-  it {should be_instance_of Date}
-  it {should respond_to :to_unit}
-  it {should respond_to :to_time}
-  it {should respond_to :to_date}  
+  it {is_expected.to be_instance_of Date}
+  it {is_expected.to respond_to :to_unit}
+  it {is_expected.to respond_to :to_time}
+  it {is_expected.to respond_to :to_date}  
   
-  specify { (subject + "5 days".unit).should == Date.new(2011,4,6) }
-  specify { (subject - "5 days".unit).should == Date.new(2011,3,27) }
+  specify { expect(subject + "5 days".unit).to eq(Date.new(2011,4,6)) }
+  specify { expect(subject - "5 days".unit).to eq(Date.new(2011,3,27)) }
   # 2012 is a leap year...
-  specify { (subject + "1 year".unit).should == Date.new(2012,3,31) }
-  specify { (subject - "1 year".unit).should == Date.new(2010,4,1) }
+  specify { expect(subject + "1 year".unit).to eq(Date.new(2012,3,31)) }
+  specify { expect(subject - "1 year".unit).to eq(Date.new(2010,4,1)) }
 end
 
 describe "Date Unit" do
 
   subject { Date.new(2011,4,1).to_unit }
 
-  it { should be_instance_of Unit }
+  it { is_expected.to be_instance_of Unit }
   its(:scalar) { should be_kind_of Rational }
   its(:units) { should == "d" }
   its(:kind) { should == :time }
 
-  specify { (subject + "5 days".unit).should == Date.new(2011,4,6) }
-  specify { (subject - "5 days".unit).should == Date.new(2011,3,27) }
+  specify { expect(subject + "5 days".unit).to eq(Date.new(2011,4,6)) }
+  specify { expect(subject - "5 days".unit).to eq(Date.new(2011,3,27)) }
 
   specify { expect { subject + Date.new(2011,4,1) }.to raise_error(ArgumentError) }
   specify { expect { subject + DateTime.new(2011,4,1,12,00,00) }.to raise_error(ArgumentError) }
   specify { expect { subject + Time.parse("2011-04-01 12:00:00") }.to raise_error(ArgumentError) }
 
-  specify { (subject - Date.new(2011,4,1)).should be_zero }
-  specify { (subject - DateTime.new(2011,4,1,00,00,00)).should be_zero }
+  specify { expect(subject - Date.new(2011,4,1)).to be_zero }
+  specify { expect(subject - DateTime.new(2011,4,1,00,00,00)).to be_zero }
   specify { expect {(subject - Time.parse("2011-04-01 00:00"))}.to raise_error(ArgumentError) }
-  specify { (Date.new(2011,4,1) + 1).should == Date.new(2011,4,2)}
+  specify { expect(Date.new(2011,4,1) + 1).to eq(Date.new(2011,4,2))}
 end

--- a/spec/ruby-units/math_spec.rb
+++ b/spec/ruby-units/math_spec.rb
@@ -3,16 +3,16 @@ require File.dirname(__FILE__) + '/../spec_helper'
 describe Math do
 
   describe "#sqrt" do
-    specify { Math.sqrt(Unit('1 mm^6')).should == Unit('1 mm^3') }
-    specify { Math.sqrt(4).should == 2 }
-    specify { Math.sqrt(Unit("-9 mm^2")).should be_kind_of(Complex) }
+    specify { expect(Math.sqrt(Unit('1 mm^6'))).to eq(Unit('1 mm^3')) }
+    specify { expect(Math.sqrt(4)).to eq(2) }
+    specify { expect(Math.sqrt(Unit("-9 mm^2"))).to be_kind_of(Complex) }
   end
 
   if RUBY_VERSION > "1.9"
   # cbrt is only defined in Ruby > 1.9
     describe '#cbrt' do
-      specify { Math.cbrt(Unit('1 mm^6')).should == Unit('1 mm^2') }
-      specify { Math.cbrt(8).should == 2 }
+      specify { expect(Math.cbrt(Unit('1 mm^6'))).to eq(Unit('1 mm^2')) }
+      specify { expect(Math.cbrt(8)).to eq(2) }
     end
   end
 
@@ -20,42 +20,42 @@ describe Math do
 
     context "with '45 deg' unit" do
       subject { Unit("45 deg") }
-      specify { Math.sin(subject).should be_within(0.01).of(0.70710678) }
-      specify { Math.cos(subject).should be_within(0.01).of(0.70710678) }
-      specify { Math.tan(subject).should be_within(0.01).of(1) }
-      specify { Math.sinh(subject).should be_within(0.01).of(0.8686709614860095) }
-      specify { Math.cosh(subject).should be_within(0.01).of(1.3246090892520057) }
-      specify { Math.tanh(subject).should be_within(0.01).of(0.6557942026326724) }
+      specify { expect(Math.sin(subject)).to be_within(0.01).of(0.70710678) }
+      specify { expect(Math.cos(subject)).to be_within(0.01).of(0.70710678) }
+      specify { expect(Math.tan(subject)).to be_within(0.01).of(1) }
+      specify { expect(Math.sinh(subject)).to be_within(0.01).of(0.8686709614860095) }
+      specify { expect(Math.cosh(subject)).to be_within(0.01).of(1.3246090892520057) }
+      specify { expect(Math.tanh(subject)).to be_within(0.01).of(0.6557942026326724) }
     end
 
     context "with 'PI/4 radians' unit" do
       subject { Unit((Math::PI/4),'radians') }
-      specify { Math.sin(subject).should be_within(0.01).of(0.70710678) }
-      specify { Math.cos(subject).should be_within(0.01).of(0.70710678) }
-      specify { Math.tan(subject).should be_within(0.01).of(1) }
-      specify { Math.sinh(subject).should be_within(0.01).of(0.8686709614860095) }
-      specify { Math.cosh(subject).should be_within(0.01).of(1.3246090892520057) }
-      specify { Math.tanh(subject).should be_within(0.01).of(0.6557942026326724) }
+      specify { expect(Math.sin(subject)).to be_within(0.01).of(0.70710678) }
+      specify { expect(Math.cos(subject)).to be_within(0.01).of(0.70710678) }
+      specify { expect(Math.tan(subject)).to be_within(0.01).of(1) }
+      specify { expect(Math.sinh(subject)).to be_within(0.01).of(0.8686709614860095) }
+      specify { expect(Math.cosh(subject)).to be_within(0.01).of(1.3246090892520057) }
+      specify { expect(Math.tanh(subject)).to be_within(0.01).of(0.6557942026326724) }
     end
 
     context "with 'PI/4' continues to work" do
       subject { (Math::PI/4) }
-      specify { Math.sin(subject).should be_within(0.01).of(0.70710678) }
-      specify { Math.cos(subject).should be_within(0.01).of(0.70710678) }
-      specify { Math.tan(subject).should be_within(0.01).of(1) }
-      specify { Math.sinh(subject).should be_within(0.01).of(0.8686709614860095) }
-      specify { Math.cosh(subject).should be_within(0.01).of(1.3246090892520057) }
-      specify { Math.tanh(subject).should be_within(0.01).of(0.6557942026326724) }
+      specify { expect(Math.sin(subject)).to be_within(0.01).of(0.70710678) }
+      specify { expect(Math.cos(subject)).to be_within(0.01).of(0.70710678) }
+      specify { expect(Math.tan(subject)).to be_within(0.01).of(1) }
+      specify { expect(Math.sinh(subject)).to be_within(0.01).of(0.8686709614860095) }
+      specify { expect(Math.cosh(subject)).to be_within(0.01).of(1.3246090892520057) }
+      specify { expect(Math.tanh(subject)).to be_within(0.01).of(0.6557942026326724) }
     end
 
-    specify { Math.hypot(Unit("1 m"), Unit("2 m")).should be_within(Unit("0.01 m")).of(Unit("2.23607 m")) }
-    specify { Math.hypot(Unit("1 m"), Unit("2 ft")).should be_within(Unit("0.01 m")).of(Unit("1.17116 m")) }
-    specify { Math.hypot(3,4).should == 5}
+    specify { expect(Math.hypot(Unit("1 m"), Unit("2 m"))).to be_within(Unit("0.01 m")).of(Unit("2.23607 m")) }
+    specify { expect(Math.hypot(Unit("1 m"), Unit("2 ft"))).to be_within(Unit("0.01 m")).of(Unit("1.17116 m")) }
+    specify { expect(Math.hypot(3,4)).to eq(5)}
     specify { expect {Math.hypot(Unit("1 m"), Unit("2 lbs")) }.to raise_error(ArgumentError) }
 
-    specify { Math.atan2(Unit("1 m"), Unit("2 m")).should be_within(0.01).of(0.4636476090008061) }
-    specify { Math.atan2(Unit("1 m"), Unit("2 ft")).should be_within(0.01).of(1.0233478888629426) }
-    specify { Math.atan2(1,1).should be_within(0.01).of(0.785398163397448)}
+    specify { expect(Math.atan2(Unit("1 m"), Unit("2 m"))).to be_within(0.01).of(0.4636476090008061) }
+    specify { expect(Math.atan2(Unit("1 m"), Unit("2 ft"))).to be_within(0.01).of(1.0233478888629426) }
+    specify { expect(Math.atan2(1,1)).to be_within(0.01).of(0.785398163397448)}
     specify { expect {Math.atan2(Unit("1 m"), Unit("2 lbs"))}.to raise_error(ArgumentError) }
   end
 end

--- a/spec/ruby-units/numeric_spec.rb
+++ b/spec/ruby-units/numeric_spec.rb
@@ -3,10 +3,10 @@ require File.dirname(__FILE__) + '/../spec_helper'
 # some rubies return an array of strings for .instance_methods and others return an array of symbols
 # so let's stringify them before we compare
 describe Numeric do
-  specify { Float.instance_methods.map {|m| m.to_s}.should include("to_unit") }
-  specify { Integer.instance_methods.map {|m| m.to_s}.should include("to_unit") }
-  specify { Fixnum.instance_methods.map {|m| m.to_s}.should include("to_unit") }
-  specify { Complex.instance_methods.map {|m| m.to_s}.should include("to_unit") }
-  specify { Bignum.instance_methods.map {|m| m.to_s}.should include("to_unit") }
-  specify { Rational.instance_methods.map {|m| m.to_s}.should include("to_unit") }
+  specify { expect(Float.instance_methods.map {|m| m.to_s}).to include("to_unit") }
+  specify { expect(Integer.instance_methods.map {|m| m.to_s}).to include("to_unit") }
+  specify { expect(Fixnum.instance_methods.map {|m| m.to_s}).to include("to_unit") }
+  specify { expect(Complex.instance_methods.map {|m| m.to_s}).to include("to_unit") }
+  specify { expect(Bignum.instance_methods.map {|m| m.to_s}).to include("to_unit") }
+  specify { expect(Rational.instance_methods.map {|m| m.to_s}).to include("to_unit") }
 end

--- a/spec/ruby-units/object_spec.rb
+++ b/spec/ruby-units/object_spec.rb
@@ -1,9 +1,9 @@
 require File.dirname(__FILE__) + '/../spec_helper'
 
 describe Object do
-  specify { Unit('1 mm').should be_instance_of Unit}
-  specify { U('1 mm').should be_instance_of Unit}
-  specify { u('1 mm').should be_instance_of Unit}
-  specify { (Unit(0) + Unit(0)).should be_instance_of Unit}
-  specify { (Unit(0) - Unit(0)).should be_instance_of Unit}
+  specify { expect(Unit('1 mm')).to be_instance_of Unit}
+  specify { expect(U('1 mm')).to be_instance_of Unit}
+  specify { expect(u('1 mm')).to be_instance_of Unit}
+  specify { expect(Unit(0) + Unit(0)).to be_instance_of Unit}
+  specify { expect(Unit(0) - Unit(0)).to be_instance_of Unit}
 end

--- a/spec/ruby-units/range_spec.rb
+++ b/spec/ruby-units/range_spec.rb
@@ -4,13 +4,13 @@ describe "Range" do
   
   context "of integer units" do
     subject { (Unit('1 mm')..Unit('3 mm')) }
-    it { should include(Unit('2 mm')) }
+    it { is_expected.to include(Unit('2 mm')) }
     its(:to_a) { should == [ Unit('1 mm'), Unit('2 mm'), Unit('3 mm') ] }
   end
   
   context "of floating point units" do
     subject { (Unit('1.5 mm')..Unit('3.5 mm')) }
-    it { should include(Unit('2.0 mm')) }
+    it { is_expected.to include(Unit('2.0 mm')) }
     specify { expect { subject.to_a }.to raise_exception(ArgumentError)}
   end
 end

--- a/spec/ruby-units/string_spec.rb
+++ b/spec/ruby-units/string_spec.rb
@@ -2,19 +2,19 @@ require File.dirname(__FILE__) + '/../spec_helper'
 
 describe String do
   context "Unit creation from strings" do
-    specify { "1 mm".to_unit.should be_instance_of Unit }
-    specify { "1 mm".unit.should be_instance_of Unit }
-    specify { "1 mm".u.should be_instance_of Unit }
-    specify { "1 m".convert_to("ft").should be_within(Unit("0.01 ft")).of Unit("3.28084 ft") }
+    specify { expect("1 mm".to_unit).to be_instance_of Unit }
+    specify { expect("1 mm".unit).to be_instance_of Unit }
+    specify { expect("1 mm".u).to be_instance_of Unit }
+    specify { expect("1 m".convert_to("ft")).to be_within(Unit("0.01 ft")).of Unit("3.28084 ft") }
   end
   
   context "output format" do
     subject { Unit("1.23456 m/s^2") }
-    specify { ("" % subject).should == ""}
-    specify { ("%0.2f" % subject).should == "1.23 m/s^2"}
-    specify { ("%0.2f km/h^2" % subject).should == "15999.90 km/h^2"}
-    specify { ("km/h^2" % subject).should == "15999.9 km/h^2"}
-    specify { ("%H:%M:%S" % Unit("1.5 h")).should == "01:30:00"}
+    specify { expect("" % subject).to eq("")}
+    specify { expect("%0.2f" % subject).to eq("1.23 m/s^2")}
+    specify { expect("%0.2f km/h^2" % subject).to eq("15999.90 km/h^2")}
+    specify { expect("km/h^2" % subject).to eq("15999.9 km/h^2")}
+    specify { expect("%H:%M:%S" % Unit("1.5 h")).to eq("01:30:00")}
   end
   
 end

--- a/spec/ruby-units/temperature_spec.rb
+++ b/spec/ruby-units/temperature_spec.rb
@@ -53,11 +53,11 @@ describe 'temperatures' do
       its(:scalar) {should be_within(0.001).of 100}
       its(:units) {should == "tC"}
       its(:kind) {should == :temperature}
-      it {should be_temperature}
-      it {should be_degree}
-      it {should_not be_base}
-      it {should_not be_unitless}
-      it {should_not be_zero}
+      it {is_expected.to be_temperature}
+      it {is_expected.to be_degree}
+      it {is_expected.not_to be_base}
+      it {is_expected.not_to be_unitless}
+      it {is_expected.not_to be_zero}
       its(:base) {should be_within(Unit("0.01 degK")).of Unit("373.15 tempK")}
       its(:temperature_scale) {should == "degC"}
     end
@@ -66,24 +66,24 @@ describe 'temperatures' do
       # note that 'temp' units are for temperature readings on a scale, while 'deg' units are used to represent
       # differences between temperatures, offsets, or other differential temperatures.
     
-      specify { Unit("100 tC").should be_within(Unit("0.001 degK")).of(Unit("373.15 tempK")) }
-      specify { Unit("0 tC").should be_within(Unit("0.001 degK")).of(Unit("273.15 tempK")) }
-      specify { Unit("37 tC").should be_within(Unit("0.01 degK")).of(Unit("310.15 tempK"))}
-      specify { Unit("-273.15 tC").should == Unit("0 tempK") }
+      specify { expect(Unit("100 tC")).to be_within(Unit("0.001 degK")).of(Unit("373.15 tempK")) }
+      specify { expect(Unit("0 tC")).to be_within(Unit("0.001 degK")).of(Unit("273.15 tempK")) }
+      specify { expect(Unit("37 tC")).to be_within(Unit("0.01 degK")).of(Unit("310.15 tempK"))}
+      specify { expect(Unit("-273.15 tC")).to eq(Unit("0 tempK")) }
     
-      specify { Unit("212 tF").should be_within(Unit("0.001 degK")).of(Unit("373.15 tempK")) }
-      specify { Unit("32 tF").should be_within(Unit("0.001 degK")).of(Unit("273.15 tempK")) }
-      specify { Unit("98.6 tF").should be_within(Unit("0.01 degK")).of(Unit("310.15 tempK"))}
-      specify { Unit("-459.67 tF").should == Unit("0 tempK") }
+      specify { expect(Unit("212 tF")).to be_within(Unit("0.001 degK")).of(Unit("373.15 tempK")) }
+      specify { expect(Unit("32 tF")).to be_within(Unit("0.001 degK")).of(Unit("273.15 tempK")) }
+      specify { expect(Unit("98.6 tF")).to be_within(Unit("0.01 degK")).of(Unit("310.15 tempK"))}
+      specify { expect(Unit("-459.67 tF")).to eq(Unit("0 tempK")) }
 
-      specify { Unit("671.67 tR").should be_within(Unit("0.001 degK")).of(Unit("373.15 tempK")) }
-      specify { Unit("491.67 tR").should be_within(Unit("0.001 degK")).of(Unit("273.15 tempK")) }
-      specify { Unit("558.27 tR").should be_within(Unit("0.01 degK")).of(Unit("310.15 tempK"))}
-      specify { Unit("0 tR").should == Unit("0 tempK") }
+      specify { expect(Unit("671.67 tR")).to be_within(Unit("0.001 degK")).of(Unit("373.15 tempK")) }
+      specify { expect(Unit("491.67 tR")).to be_within(Unit("0.001 degK")).of(Unit("273.15 tempK")) }
+      specify { expect(Unit("558.27 tR")).to be_within(Unit("0.01 degK")).of(Unit("310.15 tempK"))}
+      specify { expect(Unit("0 tR")).to eq(Unit("0 tempK")) }
     
-      specify { Unit("100 tK").convert_to("tempC").should be_within(U"0.01 degC").of(Unit("-173.15 tempC"))}
-      specify { Unit("100 tK").convert_to("tempF").should be_within(U"0.01 degF").of(Unit("-279.67 tempF"))}
-      specify { Unit("100 tK").convert_to("tempR").should be_within(U"0.01 degR").of(Unit("180 tempR"))}
+      specify { expect(Unit("100 tK").convert_to("tempC")).to be_within(U"0.01 degC").of(Unit("-173.15 tempC"))}
+      specify { expect(Unit("100 tK").convert_to("tempF")).to be_within(U"0.01 degF").of(Unit("-279.67 tempF"))}
+      specify { expect(Unit("100 tK").convert_to("tempR")).to be_within(U"0.01 degR").of(Unit("180 tempR"))}
     end
 
     

--- a/spec/ruby-units/time_spec.rb
+++ b/spec/ruby-units/time_spec.rb
@@ -3,44 +3,44 @@ require File.dirname(__FILE__) + '/../spec_helper'
 describe Time do
   let(:now) { Time.at(1303656390) }
   before(:each) do
-    Time.stub(:now).and_return(now)
+    allow(Time).to receive(:now).and_return(now)
   end
 
   context ".at" do
     subject { Date.new(2011,4,1).to_unit }
-    specify { Time.at(Time.at(0)).utc.strftime("%D %T").should == "01/01/70 00:00:00" }
-    specify { Time.at(subject - Date.new(1970,1,1)).getutc.strftime("%D %T").should == "04/01/11 00:00:00"}
-    specify { Time.at(subject - Date.new(1970,1,1), 500).usec.should == 500}
+    specify { expect(Time.at(Time.at(0)).utc.strftime("%D %T")).to eq("01/01/70 00:00:00") }
+    specify { expect(Time.at(subject - Date.new(1970,1,1)).getutc.strftime("%D %T")).to eq("04/01/11 00:00:00")}
+    specify { expect(Time.at(subject - Date.new(1970,1,1), 500).usec).to eq(500)}
   end
 
   context ".in" do
-    specify { Time.in("5 min").should be_a Time}
-    specify { Time.in("5 min").should > Time.now}
+    specify { expect(Time.in("5 min")).to be_a Time}
+    specify { expect(Time.in("5 min")).to be > Time.now}
   end
 
   context '#to_date' do
     subject { Time.parse("2012-01-31 11:59:59") }
-    specify { subject.to_date.to_s.should == "2012-01-31" }
-    specify { (subject+1).to_date.to_s.should == "2012-01-31" }
+    specify { expect(subject.to_date.to_s).to eq("2012-01-31") }
+    specify { expect((subject+1).to_date.to_s).to eq("2012-01-31") }
   end
 
   context '#to_unit' do
     subject { now }
     its(:to_unit)         { should be_an_instance_of(Unit) }
     its('to_unit.units')  { should == "s" }
-    specify               { subject.to_unit('h').kind.should == :time}
-    specify               { subject.to_unit('h').units.should == 'h'}
+    specify               { expect(subject.to_unit('h').kind).to eq(:time)}
+    specify               { expect(subject.to_unit('h').units).to eq('h')}
   end
 
   context 'addition (+)' do
-    specify { (Time.now + 1).should == Time.at(1303656390 + 1)}
-    specify { (Time.now + Unit("10 min")).should == Time.at(1303656390 + 600)}
+    specify { expect(Time.now + 1).to eq(Time.at(1303656390 + 1))}
+    specify { expect(Time.now + Unit("10 min")).to eq(Time.at(1303656390 + 600))}
   end
 
   context 'subtraction (-)' do
-    specify { (Time.now - 1).should == Time.at(1303656390 - 1)}
-    specify { (Time.now - Unit("10 min")).should == Time.at(1303656390 - 600)}
-    specify { (Time.now - Unit("150 years")).should == Time.parse("1861-04-24 09:46:30 -0500")}
+    specify { expect(Time.now - 1).to eq(Time.at(1303656390 - 1))}
+    specify { expect(Time.now - Unit("10 min")).to eq(Time.at(1303656390 - 600))}
+    specify { expect(Time.now - Unit("150 years")).to eq(Time.parse("1861-04-24 09:46:30 -0500"))}
   end
 
 end

--- a/spec/ruby-units/unit_spec.rb
+++ b/spec/ruby-units/unit_spec.rb
@@ -2,10 +2,10 @@ require File.dirname(__FILE__) + '/../spec_helper'
 require 'yaml'
 
 describe Unit.base_units do
-  it { should be_a Array }
-  it { should have(14).elements }
+  it { is_expected.to be_a Array }
+  its(:size) { should eq 14 }
   %w{kilogram meter second ampere degK tempK mole candela each dollar steradian radian decibel byte}.each do |u|
-    it { should include(Unit(u)) }
+    it { is_expected.to include(Unit(u)) }
   end
 end
 
@@ -14,369 +14,369 @@ describe "Create some simple units" do
 
   # zero string
   describe Unit("0") do
-    it { should be_a Numeric }
-    it { should be_an_instance_of Unit }
+    it { is_expected.to be_a Numeric }
+    it { is_expected.to be_an_instance_of Unit }
     its(:scalar) { should === 0 }
     its(:scalar) { should be_an Integer }
     its(:units) { should be_empty }
     its(:kind) { should == :unitless }
-    it { should_not be_temperature }
-    it { should_not be_degree }
-    it { should be_base }
-    it { should be_unitless }
-    it { should be_zero }
+    it { is_expected.not_to be_temperature }
+    it { is_expected.not_to be_degree }
+    it { is_expected.to be_base }
+    it { is_expected.to be_unitless }
+    it { is_expected.to be_zero }
     its(:base) { should == subject }
   end
 
   # non-zero string
   describe Unit("1") do
-    it { should be_a Numeric }
-    it { should be_an_instance_of Unit }
+    it { is_expected.to be_a Numeric }
+    it { is_expected.to be_an_instance_of Unit }
     its(:scalar) { should === 1 }
     its(:scalar) { should be_an Integer }
     its(:units) { should be_empty }
     its(:kind) { should == :unitless }
-    it { should_not be_temperature }
-    it { should_not be_degree }
-    it { should be_base }
-    it { should be_unitless }
-    it { should_not be_zero }
+    it { is_expected.not_to be_temperature }
+    it { is_expected.not_to be_degree }
+    it { is_expected.to be_base }
+    it { is_expected.to be_unitless }
+    it { is_expected.not_to be_zero }
     its(:base) { should == subject }
   end
 
   # numeric
   describe Unit(1) do
-    it { should be_a Numeric }
-    it { should be_an_instance_of Unit }
+    it { is_expected.to be_a Numeric }
+    it { is_expected.to be_an_instance_of Unit }
     its(:scalar) { should === 1 }
     its(:scalar) { should be_an Integer }
     its(:units) { should be_empty }
     its(:kind) { should == :unitless }
-    it { should_not be_temperature }
-    it { should_not be_degree }
-    it { should be_base }
-    it { should be_unitless }
-    it { should_not be_zero }
+    it { is_expected.not_to be_temperature }
+    it { is_expected.not_to be_degree }
+    it { is_expected.to be_base }
+    it { is_expected.to be_unitless }
+    it { is_expected.not_to be_zero }
     its(:base) { should == subject }
   end
 
   # rational
   describe Unit(Rational(1, 2)) do
-    it { should be_a Numeric }
-    it { should be_an_instance_of Unit }
+    it { is_expected.to be_a Numeric }
+    it { is_expected.to be_an_instance_of Unit }
     its(:scalar) { should === Rational(1, 2) }
     its(:scalar) { should be_a Rational }
     its(:units) { should be_empty }
     its(:kind) { should == :unitless }
-    it { should_not be_temperature }
-    it { should_not be_degree }
-    it { should be_base }
-    it { should be_unitless }
-    it { should_not be_zero }
+    it { is_expected.not_to be_temperature }
+    it { is_expected.not_to be_degree }
+    it { is_expected.to be_base }
+    it { is_expected.to be_unitless }
+    it { is_expected.not_to be_zero }
     its(:base) { should == subject }
   end
 
   # float
   describe Unit(0.5) do
-    it { should be_a Numeric }
-    it { should be_an_instance_of Unit }
+    it { is_expected.to be_a Numeric }
+    it { is_expected.to be_an_instance_of Unit }
     its(:scalar) { should === 0.5 }
     its(:scalar) { should be_a Float }
     its(:units) { should be_empty }
     its(:kind) { should == :unitless }
-    it { should_not be_temperature }
-    it { should_not be_degree }
-    it { should be_base }
-    it { should be_unitless }
-    it { should_not be_zero }
+    it { is_expected.not_to be_temperature }
+    it { is_expected.not_to be_degree }
+    it { is_expected.to be_base }
+    it { is_expected.to be_unitless }
+    it { is_expected.not_to be_zero }
     its(:base) { should == subject }
   end
 
   # complex
   describe Unit(Complex(1, 1)) do
-    it { should be_a Numeric }
-    it { should be_an_instance_of Unit }
+    it { is_expected.to be_a Numeric }
+    it { is_expected.to be_an_instance_of Unit }
     its(:scalar) { should === Complex(1, 1) }
     its(:scalar) { should be_a Complex }
     its(:units) { should be_empty }
     its(:kind) { should == :unitless }
-    it { should_not be_temperature }
-    it { should_not be_degree }
-    it { should be_base }
-    it { should be_unitless }
-    it { should_not be_zero }
+    it { is_expected.not_to be_temperature }
+    it { is_expected.not_to be_degree }
+    it { is_expected.to be_base }
+    it { is_expected.to be_unitless }
+    it { is_expected.not_to be_zero }
     its(:base) { should == subject }
   end
 
   describe Unit("1+1i m") do
-    it { should be_a Numeric }
-    it { should be_an_instance_of Unit }
+    it { is_expected.to be_a Numeric }
+    it { is_expected.to be_an_instance_of Unit }
     its(:scalar) { should === Complex(1, 1) }
     its(:scalar) { should be_a Complex }
     its(:units) { should == "m" }
     its(:kind) { should == :length }
-    it { should_not be_temperature }
-    it { should_not be_degree }
-    it { should be_base }
-    it { should_not be_unitless }
-    it { should_not be_zero }
+    it { is_expected.not_to be_temperature }
+    it { is_expected.not_to be_degree }
+    it { is_expected.to be_base }
+    it { is_expected.not_to be_unitless }
+    it { is_expected.not_to be_zero }
     its(:base) { should == subject }
   end
 
   # scalar and unit
   describe Unit("1 mm") do
-    it { should be_a Numeric }
-    it { should be_an_instance_of Unit }
+    it { is_expected.to be_a Numeric }
+    it { is_expected.to be_an_instance_of Unit }
     its(:scalar) { should == 1 }
     its(:scalar) { should be_an Integer }
     its(:units) { should == "mm" }
     its(:kind) { should == :length }
-    it { should_not be_temperature }
-    it { should_not be_degree }
-    it { should_not be_base }
-    it { should_not be_unitless }
-    it { should_not be_zero }
+    it { is_expected.not_to be_temperature }
+    it { is_expected.not_to be_degree }
+    it { is_expected.not_to be_base }
+    it { is_expected.not_to be_unitless }
+    it { is_expected.not_to be_zero }
     its(:base) { should == Unit("0.001 m") }
   end
 
   # with a zero power
   describe Unit("1 m^0") do
-    it { should be_a Numeric }
-    it { should be_an_instance_of Unit }
+    it { is_expected.to be_a Numeric }
+    it { is_expected.to be_an_instance_of Unit }
     its(:scalar) { should == 1 }
     its(:scalar) { should be_an Integer }
     its(:units) { should == "" }
     its(:kind) { should == :unitless }
-    it { should_not be_temperature }
-    it { should_not be_degree }
-    it { should be_base }
-    it { should be_unitless }
-    it { should_not be_zero }
+    it { is_expected.not_to be_temperature }
+    it { is_expected.not_to be_degree }
+    it { is_expected.to be_base }
+    it { is_expected.to be_unitless }
+    it { is_expected.not_to be_zero }
     its(:base) { should == Unit("1") }
   end
 
   # unit only
   describe Unit("mm") do
-    it { should be_a Numeric }
-    it { should be_an_instance_of Unit }
+    it { is_expected.to be_a Numeric }
+    it { is_expected.to be_an_instance_of Unit }
     its(:scalar) { should == 1 }
     its(:scalar) { should be_an Integer }
     its(:units) { should == "mm" }
     its(:kind) { should == :length }
-    it { should_not be_temperature }
-    it { should_not be_degree }
-    it { should_not be_base }
-    it { should_not be_unitless }
-    it { should_not be_zero }
+    it { is_expected.not_to be_temperature }
+    it { is_expected.not_to be_degree }
+    it { is_expected.not_to be_base }
+    it { is_expected.not_to be_unitless }
+    it { is_expected.not_to be_zero }
     its(:base) { should == Unit("0.001 m") }
   end
 
   # Compound unit
   describe Unit("1 N*m") do
-    it { should be_a Numeric }
-    it { should be_an_instance_of Unit }
+    it { is_expected.to be_a Numeric }
+    it { is_expected.to be_an_instance_of Unit }
     its(:scalar) { should == 1 }
     its(:scalar) { should be_an Integer }
     its(:units) { should == "N*m" }
     its(:kind) { should == :energy }
-    it { should_not be_temperature }
-    it { should_not be_degree }
-    it { should_not be_base }
-    it { should_not be_unitless }
-    it { should_not be_zero }
+    it { is_expected.not_to be_temperature }
+    it { is_expected.not_to be_degree }
+    it { is_expected.not_to be_base }
+    it { is_expected.not_to be_unitless }
+    it { is_expected.not_to be_zero }
     its(:base) { should == Unit("1 kg*m^2/s^2") }
   end
 
   # scalar and unit with powers
   describe Unit("10 m/s^2") do
-    it { should be_an_instance_of Unit }
+    it { is_expected.to be_an_instance_of Unit }
     its(:scalar) { should == 10 }
     its(:scalar) { should be_an Integer }
     its(:units) { should == "m/s^2" }
     its(:kind) { should == :acceleration }
-    it { should_not be_temperature }
-    it { should_not be_degree }
-    it { should be_base }
-    it { should_not be_unitless }
-    it { should_not be_zero }
+    it { is_expected.not_to be_temperature }
+    it { is_expected.not_to be_degree }
+    it { is_expected.to be_base }
+    it { is_expected.not_to be_unitless }
+    it { is_expected.not_to be_zero }
     its(:base) { should == Unit("10 m/s^2") }
   end
 
   # feet/in form
   describe Unit("5ft 6in") do
-    it { should be_an_instance_of Unit }
+    it { is_expected.to be_an_instance_of Unit }
     its(:scalar) { should == 5.5 }
     its(:units) { should == "ft" }
     its(:kind) { should == :length }
-    it { should_not be_temperature }
-    it { should_not be_degree }
-    it { should_not be_base }
-    it { should_not be_unitless }
-    it { should_not be_zero }
+    it { is_expected.not_to be_temperature }
+    it { is_expected.not_to be_degree }
+    it { is_expected.not_to be_base }
+    it { is_expected.not_to be_unitless }
+    it { is_expected.not_to be_zero }
     its(:base) { should be_within(Unit("0.01 m")).of Unit("1.6764 m") }
-    specify { subject.to_s(:ft).should == %{5'6"} }
+    specify { expect(subject.to_s(:ft)).to eq(%{5'6"}) }
   end
 
   # pound/ounces form
   describe Unit("6lbs 5oz") do
-    it { should be_an_instance_of Unit }
+    it { is_expected.to be_an_instance_of Unit }
     its(:scalar) { should be_within(0.001).of 6.312 }
     its(:units) { should == "lbs" }
     its(:kind) { should == :mass }
-    it { should_not be_temperature }
-    it { should_not be_degree }
-    it { should_not be_base }
-    it { should_not be_unitless }
-    it { should_not be_zero }
+    it { is_expected.not_to be_temperature }
+    it { is_expected.not_to be_degree }
+    it { is_expected.not_to be_base }
+    it { is_expected.not_to be_unitless }
+    it { is_expected.not_to be_zero }
     its(:base) { should be_within(Unit("0.01 kg")).of Unit("2.8633 kg") }
-    specify { subject.to_s(:lbs).should == "6 lbs, 5 oz" }
+    specify { expect(subject.to_s(:lbs)).to eq("6 lbs, 5 oz") }
   end
 
   # temperature
   describe Unit("100 tempC") do
-    it { should be_an_instance_of Unit }
+    it { is_expected.to be_an_instance_of Unit }
     its(:scalar) { should be_within(0.001).of 100 }
     its(:units) { should == "tempC" }
     its(:kind) { should == :temperature }
-    it { should be_temperature }
-    it { should be_degree }
-    it { should_not be_base }
-    it { should_not be_unitless }
-    it { should_not be_zero }
+    it { is_expected.to be_temperature }
+    it { is_expected.to be_degree }
+    it { is_expected.not_to be_base }
+    it { is_expected.not_to be_unitless }
+    it { is_expected.not_to be_zero }
     its(:base) { should be_within(Unit("0.01 degK")).of Unit("373.15 tempK") }
     its(:temperature_scale) { should == "degC" }
   end
 
   # Time
   describe Unit(Time.now) do
-    it { should be_an_instance_of Unit }
+    it { is_expected.to be_an_instance_of Unit }
     its(:scalar) { should be_a(Numeric) }
     its(:units) { should == "s" }
     its(:kind) { should == :time }
-    it { should_not be_temperature }
-    it { should_not be_degree }
-    it { should be_base }
-    it { should_not be_unitless }
-    it { should_not be_zero }
+    it { is_expected.not_to be_temperature }
+    it { is_expected.not_to be_degree }
+    it { is_expected.to be_base }
+    it { is_expected.not_to be_unitless }
+    it { is_expected.not_to be_zero }
     its(:base) { should be_a(Numeric) }
     its(:temperature_scale) { should be_nil }
   end
 
   # degrees
   describe Unit("100 degC") do
-    it { should be_an_instance_of Unit }
+    it { is_expected.to be_an_instance_of Unit }
     its(:scalar) { should be_within(0.001).of 100 }
     its(:units) { should == "degC" }
     its(:kind) { should == :temperature }
-    it { should_not be_temperature }
-    it { should be_degree }
-    it { should_not be_base }
-    it { should_not be_unitless }
+    it { is_expected.not_to be_temperature }
+    it { is_expected.to be_degree }
+    it { is_expected.not_to be_base }
+    it { is_expected.not_to be_unitless }
     its(:base) { should be_within(Unit("0.01 degK")).of Unit("100 degK") }
   end
 
   # percent
   describe Unit("75%") do
-    it { should be_an_instance_of Unit }
+    it { is_expected.to be_an_instance_of Unit }
     its(:scalar) { should be_an Integer }
     its(:units) { should == "%" }
     its(:kind) { should == :unitless }
-    it { should_not be_temperature }
-    it { should_not be_degree }
-    it { should_not be_base }
-    it { should_not be_unitless }
-    it { should_not be_zero }
+    it { is_expected.not_to be_temperature }
+    it { is_expected.not_to be_degree }
+    it { is_expected.not_to be_base }
+    it { is_expected.not_to be_unitless }
+    it { is_expected.not_to be_zero }
     its(:base) { should be_a(Numeric) }
     its(:temperature_scale) { should be_nil }
   end
 
   # angle
   describe Unit("180 deg") do
-    it { should be_an_instance_of Unit }
+    it { is_expected.to be_an_instance_of Unit }
     its(:scalar) { should be_a Numeric }
     its(:units) { should == "deg" }
     its(:kind) { should == :angle }
-    it { should_not be_temperature }
-    it { should_not be_degree }
-    it { should_not be_base }
-    it { should_not be_unitless }
-    it { should_not be_zero }
+    it { is_expected.not_to be_temperature }
+    it { is_expected.not_to be_degree }
+    it { is_expected.not_to be_base }
+    it { is_expected.not_to be_unitless }
+    it { is_expected.not_to be_zero }
     its(:base) { should be_a(Numeric) }
     its(:temperature_scale) { should be_nil }
   end
 
   # radians
   describe Unit("1 radian") do
-    it { should be_an_instance_of Unit }
+    it { is_expected.to be_an_instance_of Unit }
     its(:scalar) { should be_a Numeric }
     its(:units) { should == "rad" }
     its(:kind) { should == :angle }
-    it { should_not be_temperature }
-    it { should_not be_degree }
-    it { should be_base }
-    it { should_not be_unitless }
-    it { should_not be_zero }
+    it { is_expected.not_to be_temperature }
+    it { is_expected.not_to be_degree }
+    it { is_expected.to be_base }
+    it { is_expected.not_to be_unitless }
+    it { is_expected.not_to be_zero }
     its(:base) { should be_a Numeric }
     its(:temperature_scale) { should be_nil }
   end
 
   # counting
   describe Unit("12 dozen") do
-    it { should be_an_instance_of Unit }
+    it { is_expected.to be_an_instance_of Unit }
     its(:scalar) { should be_an Integer }
     its(:units) { should == "doz" }
     its(:kind) { should == :unitless }
-    it { should_not be_temperature }
-    it { should_not be_degree }
-    it { should_not be_base }
-    it { should_not be_unitless }
-    it { should_not be_zero }
+    it { is_expected.not_to be_temperature }
+    it { is_expected.not_to be_degree }
+    it { is_expected.not_to be_base }
+    it { is_expected.not_to be_unitless }
+    it { is_expected.not_to be_zero }
     its(:base) { should be_a Numeric }
     its(:temperature_scale) { should be_nil }
   end
 
   # rational scalar with unit
   describe Unit("1/2 kg") do
-    it { should be_an_instance_of Unit }
+    it { is_expected.to be_an_instance_of Unit }
     its(:scalar) { should be_an Rational }
     its(:units) { should == "kg" }
     its(:kind) { should == :mass }
-    it { should_not be_temperature }
-    it { should_not be_degree }
-    it { should be_base }
-    it { should_not be_unitless }
-    it { should_not be_zero }
+    it { is_expected.not_to be_temperature }
+    it { is_expected.not_to be_degree }
+    it { is_expected.to be_base }
+    it { is_expected.not_to be_unitless }
+    it { is_expected.not_to be_zero }
     its(:base) { should be_a Numeric }
     its(:temperature_scale) { should be_nil }
   end
 
   # rational scalar with compound unit
   describe Unit("1/2 kg/m") do
-    it { should be_an_instance_of Unit }
+    it { is_expected.to be_an_instance_of Unit }
     its(:scalar) { should be_an Rational }
     its(:units) { should == "kg/m" }
     its(:kind) { should be_nil }
-    it { should_not be_temperature }
-    it { should_not be_degree }
-    it { should be_base }
-    it { should_not be_unitless }
-    it { should_not be_zero }
+    it { is_expected.not_to be_temperature }
+    it { is_expected.not_to be_degree }
+    it { is_expected.to be_base }
+    it { is_expected.not_to be_unitless }
+    it { is_expected.not_to be_zero }
     its(:base) { should be_a Numeric }
     its(:temperature_scale) { should be_nil }
   end
 
   # time string
   describe Unit("1:23:45,200") do
-    it { should be_an_instance_of Unit }
-    it { should == Unit("1 h") + Unit("23 min") + Unit("45 seconds") + Unit("200 usec") }
+    it { is_expected.to be_an_instance_of Unit }
+    it { is_expected.to eq(Unit("1 h") + Unit("23 min") + Unit("45 seconds") + Unit("200 usec")) }
     its(:scalar) { should be_an Rational }
     its(:units) { should == "h" }
     its(:kind) { should == :time }
-    it { should_not be_temperature }
-    it { should_not be_degree }
-    it { should_not be_base }
-    it { should_not be_unitless }
-    it { should_not be_zero }
+    it { is_expected.not_to be_temperature }
+    it { is_expected.not_to be_degree }
+    it { is_expected.not_to be_base }
+    it { is_expected.not_to be_unitless }
+    it { is_expected.not_to be_zero }
     its(:base) { should be_a Numeric }
     its(:temperature_scale) { should be_nil }
   end
@@ -384,90 +384,90 @@ describe "Create some simple units" do
   # also  '1 hours as minutes'
   #       '1 hour to minutes'
   describe Unit.parse("1 hour in minutes") do
-    it { should be_an_instance_of Unit }
+    it { is_expected.to be_an_instance_of Unit }
     its(:scalar) { should be_an Integer }
     its(:units) { should == "min" }
     its(:kind) { should == :time }
-    it { should_not be_temperature }
-    it { should_not be_degree }
-    it { should_not be_base }
-    it { should_not be_unitless }
-    it { should_not be_zero }
+    it { is_expected.not_to be_temperature }
+    it { is_expected.not_to be_degree }
+    it { is_expected.not_to be_base }
+    it { is_expected.not_to be_unitless }
+    it { is_expected.not_to be_zero }
     its(:base) { should be_a Numeric }
     its(:temperature_scale) { should be_nil }
   end
 
   # funky unit
   describe Unit("1 attoparsec/microfortnight") do
-    it { should be_an_instance_of Unit }
+    it { is_expected.to be_an_instance_of Unit }
     its(:scalar) { should be_an Integer }
     its(:units) { should == "apc/ufortnight" }
     its(:kind) { should == :speed }
-    it { should_not be_temperature }
-    it { should_not be_degree }
-    it { should_not be_base }
-    it { should_not be_unitless }
-    it { should_not be_zero }
+    it { is_expected.not_to be_temperature }
+    it { is_expected.not_to be_degree }
+    it { is_expected.not_to be_base }
+    it { is_expected.not_to be_unitless }
+    it { is_expected.not_to be_zero }
     its(:base) { should be_a Numeric }
     its(:temperature_scale) { should be_nil }
-    it { subject.convert_to("in/s").should be_within(Unit("0.0001 in/s")).of(Unit("1.0043269330917 in/s")) }
+    it { expect(subject.convert_to("in/s")).to be_within(Unit("0.0001 in/s")).of(Unit("1.0043269330917 in/s")) }
   end
 
   # Farads
   describe Unit("1 F") do
-    it { should be_an_instance_of Unit }
+    it { is_expected.to be_an_instance_of Unit }
     its(:scalar) { should be_an Integer }
     its(:units) { should == "F" }
     its(:kind) { should == :capacitance }
-    it { should_not be_temperature }
-    it { should_not be_degree }
-    it { should_not be_base }
-    it { should_not be_unitless }
-    it { should_not be_zero }
+    it { is_expected.not_to be_temperature }
+    it { is_expected.not_to be_degree }
+    it { is_expected.not_to be_base }
+    it { is_expected.not_to be_unitless }
+    it { is_expected.not_to be_zero }
     its(:base) { should be_a Numeric }
     its(:temperature_scale) { should be_nil }
   end
 
   describe Unit("1 m^2 s^-2") do
-    it { should be_an_instance_of Unit }
+    it { is_expected.to be_an_instance_of Unit }
     its(:scalar) { should be_an Integer }
     its(:units) { should == "m^2/s^2" }
     its(:kind) { should == :radiation }
-    it { should_not be_temperature }
-    it { should_not be_degree }
-    it { should be_base }
-    it { should_not be_unitless }
-    it { should_not be_zero }
+    it { is_expected.not_to be_temperature }
+    it { is_expected.not_to be_degree }
+    it { is_expected.to be_base }
+    it { is_expected.not_to be_unitless }
+    it { is_expected.not_to be_zero }
     its(:base) { should be_a Numeric }
     its(:temperature_scale) { should be_nil }
   end
 
   describe Unit(1, "m^2", "s^2") do
-    it { should be_an_instance_of Unit }
+    it { is_expected.to be_an_instance_of Unit }
     its(:scalar) { should be_an Integer }
     its(:units) { should == "m^2/s^2" }
     its(:kind) { should == :radiation }
-    it { should_not be_temperature }
-    it { should_not be_degree }
-    it { should be_base }
-    it { should_not be_unitless }
-    it { should_not be_zero }
+    it { is_expected.not_to be_temperature }
+    it { is_expected.not_to be_degree }
+    it { is_expected.to be_base }
+    it { is_expected.not_to be_unitless }
+    it { is_expected.not_to be_zero }
     its(:base) { should be_a Numeric }
     its(:temperature_scale) { should be_nil }
   end
 
   #scientific notation
   describe Unit("1e6 cells") do
-    it { should be_an_instance_of Unit }
+    it { is_expected.to be_an_instance_of Unit }
     its(:scalar) { should be_an Integer }
     its(:scalar) { should == 1e6 }
     its(:units) { should == "cells" }
     its(:kind) { should == :unitless }
-    it { should_not be_temperature }
-    it { should_not be_degree }
-    it { should_not be_base }
-    it { should_not be_unitless }
-    it { should_not be_zero }
+    it { is_expected.not_to be_temperature }
+    it { is_expected.not_to be_degree }
+    it { is_expected.not_to be_base }
+    it { is_expected.not_to be_unitless }
+    it { is_expected.not_to be_zero }
     its(:base) { should be_a Numeric }
     its(:temperature_scale) { should be_nil }
   end
@@ -516,29 +516,29 @@ describe "Create some simple units" do
 
   # without spaces
   describe Unit('1g') do
-    specify { subject.should eq(Unit('1 g')) }
+    specify { expect(subject).to eq(Unit('1 g')) }
   end
 
   describe Unit('-1g') do
-    specify { subject.should eq(Unit('-1 g')) }
+    specify { expect(subject).to eq(Unit('-1 g')) }
   end
 
   describe Unit('11/s') do
-    specify { subject.should eq(Unit('11 1/s')) }
+    specify { expect(subject).to eq(Unit('11 1/s')) }
   end
 
   describe Unit.new("63.5029318kg") do
-    specify { subject.should eq(Unit.new("63.5029318 kg")) }
+    specify { expect(subject).to eq(Unit.new("63.5029318 kg")) }
   end
 
   # mixed fraction
   describe Unit.new('6 1/2 cups') do
-    specify { subject.should eq(Unit.new('13/2 cu')) }
+    specify { expect(subject).to eq(Unit.new('13/2 cu')) }
   end
 
   # mixed fraction
   describe Unit.new('-6-1/2 cups') do
-    specify { subject.should eq(Unit.new('-13/2 cu')) }
+    specify { expect(subject).to eq(Unit.new('-13/2 cu')) }
   end
 
   describe Unit.new('100 mcg') do
@@ -624,24 +624,24 @@ end
 
 describe Unit do
   it "is a subclass of Numeric" do
-    described_class.should < Numeric
+    expect(described_class).to be < Numeric
   end
 
   it "is Comparable" do
-    described_class.should < Comparable
+    expect(described_class).to be < Comparable
   end
 
   describe "#defined?" do
     it "should return true when asked about a defined unit" do
-      Unit.defined?("meter").should be_true
+      expect(Unit.defined?("meter")).to be_truthy
     end
 
     it "should return true when asked about an alias for a unit" do
-      Unit.defined?("m").should be_true
+      expect(Unit.defined?("m")).to be_truthy
     end
 
     it "should return false when asked about a unit that is not defined" do
-      Unit.defined?("doohickey").should be_false
+      expect(Unit.defined?("doohickey")).to be_falsey
     end
   end
 
@@ -657,20 +657,20 @@ describe Unit do
       end
 
       it "should return a Unit::Definition" do
-        @definition.should be_instance_of(Unit::Definition)
+        expect(@definition).to be_instance_of(Unit::Definition)
       end
 
-      specify { @definition.name.should == "<mph>" }
-      specify { @definition.aliases.should == %w{mph} }
-      specify { @definition.numerator.should == ['<meter>'] }
-      specify { @definition.denominator.should == ['<second>'] }
-      specify { @definition.kind.should == :speed }
-      specify { @definition.scalar.should === 0.44704 }
+      specify { expect(@definition.name).to eq("<mph>") }
+      specify { expect(@definition.aliases).to eq(%w{mph}) }
+      specify { expect(@definition.numerator).to eq(['<meter>']) }
+      specify { expect(@definition.denominator).to eq(['<second>']) }
+      specify { expect(@definition.kind).to eq(:speed) }
+      specify { expect(@definition.scalar).to be === 0.44704 }
     end
 
     context "The requested unit is not defined" do
       it "should return nil" do
-        Unit.definition("doohickey").should be_nil
+        expect(Unit.definition("doohickey")).to be_nil
       end
     end
   end
@@ -694,22 +694,22 @@ describe Unit do
         # do this because the unit is not defined at the time this file is parsed, so it fails
         subject { Unit("1e6 jiffy") }
 
-        it { should be_a Numeric }
-        it { should be_an_instance_of Unit }
+        it { is_expected.to be_a Numeric }
+        it { is_expected.to be_an_instance_of Unit }
         its(:scalar) { should == 1e6 }
         its(:scalar) { should be_an Integer }
         its(:units) { should == "jif" }
         its(:kind) { should == :time }
-        it { should_not be_temperature }
-        it { should_not be_degree }
-        it { should_not be_base }
-        it { should_not be_unitless }
-        it { should_not be_zero }
+        it { is_expected.not_to be_temperature }
+        it { is_expected.not_to be_degree }
+        it { is_expected.not_to be_base }
+        it { is_expected.not_to be_unitless }
+        it { is_expected.not_to be_zero }
         its(:base) { should == Unit("10000 s") }
       end
 
       it "should register the new unit" do
-        Unit.defined?('jiffy').should be_true
+        expect(Unit.defined?('jiffy')).to be_truthy
       end
     end
 
@@ -731,17 +731,17 @@ describe Unit do
         # do this because the unit is going to be redefined
         subject { Unit("1 cup") }
 
-        it { should be_a Numeric }
-        it { should be_an_instance_of Unit }
+        it { is_expected.to be_a Numeric }
+        it { is_expected.to be_an_instance_of Unit }
         its(:scalar) { should == 1 }
         its(:scalar) { should be_an Integer }
         its(:units) { should == "cupz" }
         its(:kind) { should == :volume }
-        it { should_not be_temperature }
-        it { should_not be_degree }
-        it { should_not be_base }
-        it { should_not be_unitless }
-        it { should_not be_zero }
+        it { is_expected.not_to be_temperature }
+        it { is_expected.not_to be_degree }
+        it { is_expected.not_to be_base }
+        it { is_expected.not_to be_unitless }
+        it { is_expected.not_to be_zero }
       end
 
     end
@@ -766,7 +766,7 @@ describe Unit do
       Unit.undefine!("jiffy")
     end
 
-    specify { Unit('1 jiffy').to_base.scalar.should == (1/1000) }
+    specify { expect(Unit('1 jiffy').to_base.scalar).to eq(1/1000) }
   end
 
   describe '#undefine!' do
@@ -781,7 +781,7 @@ describe Unit do
     end
 
     specify "the unit should be undefined" do
-      Unit.defined?('jiffy').should be_false
+      expect(Unit.defined?('jiffy')).to be_falsey
     end
 
     specify "attempting to use an undefined unit fails" do
@@ -789,8 +789,8 @@ describe Unit do
     end
 
     it "should return true when undefining an unknown unit" do
-      Unit.defined?("unknown").should be_false
-      Unit.undefine!("unknown").should be_true
+      expect(Unit.defined?("unknown")).to be_falsey
+      expect(Unit.undefine!("unknown")).to be_truthy
     end
 
   end
@@ -803,82 +803,82 @@ end
 
 describe "Unit Comparisons" do
   context "Unit should detect if two units are 'compatible' (i.e., can be converted into each other)" do
-    specify { Unit("1 ft").should =~ Unit('1 m') }
-    specify { Unit("1 ft").should =~ "m" }
-    specify { Unit("1 ft").should be_compatible_with Unit('1 m') }
-    specify { Unit("1 ft").should be_compatible_with "m" }
-    specify { Unit("1 m").should be_compatible_with Unit('1 kg*m/kg') }
-    specify { Unit("1 ft").should_not =~ Unit('1 kg') }
-    specify { Unit("1 ft").should_not be_compatible_with Unit('1 kg') }
-    specify { Unit("1 ft").should_not be_compatible_with nil }
+    specify { expect(Unit("1 ft")).to_not be === Unit('1 m') }
+    specify { expect(Unit("1 ft")).to_not be === "m" }
+    specify { expect(Unit("1 ft")).to be_compatible_with Unit('1 m') }
+    specify { expect(Unit("1 ft")).to be_compatible_with "m" }
+    specify { expect(Unit("1 m")).to be_compatible_with Unit('1 kg*m/kg') }
+    specify { expect(Unit("1 ft")).not_to be === Unit('1 kg') }
+    specify { expect(Unit("1 ft")).not_to be_compatible_with Unit('1 kg') }
+    specify { expect(Unit("1 ft")).not_to be_compatible_with nil }
   end
 
   context "Equality" do
 
     context "with uncoercable objects" do
-      specify { Unit("1 mm").should_not == nil }
+      specify { expect(Unit("1 mm")).not_to eq(nil) }
     end
 
     context "units of same kind" do
-      specify { Unit("1000 m").should == Unit('1 km') }
-      specify { Unit("100 m").should_not == Unit('1 km') }
-      specify { Unit("1 m").should == Unit('100 cm') }
+      specify { expect(Unit("1000 m")).to eq(Unit('1 km')) }
+      specify { expect(Unit("100 m")).not_to eq(Unit('1 km')) }
+      specify { expect(Unit("1 m")).to eq(Unit('100 cm')) }
     end
 
     context "units of incompatible types" do
-      specify { Unit("1 m").should_not == Unit("1 kg") }
+      specify { expect(Unit("1 m")).not_to eq(Unit("1 kg")) }
     end
 
     context "units with a zero scalar are equal" do
-      specify { Unit("0 m").should == Unit("0 s") }
-      specify { Unit("0 m").should == Unit("0 kg") }
+      specify { expect(Unit("0 m")).to eq(Unit("0 s")) }
+      specify { expect(Unit("0 m")).to eq(Unit("0 kg")) }
 
       context "except for temperature units" do
-        specify { Unit("0 tempK").should == Unit("0 m") }
-        specify { Unit("0 tempR").should == Unit("0 m") }
-        specify { Unit("0 tempC").should_not == Unit("0 m") }
-        specify { Unit("0 tempF").should_not == Unit("0 m") }
+        specify { expect(Unit("0 tempK")).to eq(Unit("0 m")) }
+        specify { expect(Unit("0 tempR")).to eq(Unit("0 m")) }
+        specify { expect(Unit("0 tempC")).not_to eq(Unit("0 m")) }
+        specify { expect(Unit("0 tempF")).not_to eq(Unit("0 m")) }
       end
     end
   end
 
   context "Equivalence" do
     context "units and scalars are the exactly the same" do
-      specify { Unit("1 m").should === Unit("1 m") }
-      specify { Unit("1 m").should be_same Unit("1 m") }
-      specify { Unit("1 m").should be_same_as Unit("1 m") }
+      specify { expect(Unit("1 m")).to be === Unit("1 m") }
+      specify { expect(Unit("1 m")).to be_same Unit("1 m") }
+      specify { expect(Unit("1 m")).to be_same_as Unit("1 m") }
     end
 
     context "units are compatible but not identical" do
-      specify { Unit("1000 m").should_not === Unit("1 km") }
-      specify { Unit("1000 m").should_not be_same Unit("1 km") }
-      specify { Unit("1000 m").should_not be_same_as Unit("1 km") }
+      specify { expect(Unit("1000 m")).not_to be === Unit("1 km") }
+      specify { expect(Unit("1000 m")).not_to be_same Unit("1 km") }
+      specify { expect(Unit("1000 m")).not_to be_same_as Unit("1 km") }
     end
 
     context "units are not compatible" do
-      specify { Unit("1000 m").should_not === Unit("1 hour") }
-      specify { Unit("1000 m").should_not be_same Unit("1 hour") }
-      specify { Unit("1000 m").should_not be_same_as Unit("1 hour") }
+      specify { expect(Unit("1000 m")).not_to be === Unit("1 hour") }
+      specify { expect(Unit("1000 m")).not_to be_same Unit("1 hour") }
+      specify { expect(Unit("1000 m")).not_to be_same_as Unit("1 hour") }
     end
 
     context "scalars are different" do
-      specify { Unit("1 m").should_not === Unit("2 m") }
-      specify { Unit("1 m").should_not be_same Unit("2 m") }
-      specify { Unit("1 m").should_not be_same_as Unit("2 m") }
+      specify { expect(Unit("1 m")).not_to be === Unit("2 m") }
+      specify { expect(Unit("1 m")).not_to be_same Unit("2 m") }
+      specify { expect(Unit("1 m")).not_to be_same_as Unit("2 m") }
     end
 
-    specify { Unit("1 m").should_not === nil }
+    specify { expect(Unit("1 m")).not_to be === nil }
   end
 
   context "Comparisons" do
     context "compatible units can be compared" do
-      specify { Unit("1 m").should < Unit("2 m") }
-      specify { Unit("2 m").should > Unit("1 m") }
-      specify { Unit("1 m").should < Unit("1 mi") }
-      specify { Unit("2 m").should > Unit("1 ft") }
-      specify { Unit("70 tempF").should > Unit("10 degC") }
-      specify { Unit("1 m").should > 0 }
-      specify { expect { Unit("1 m").should_not > nil }.to raise_error(ArgumentError, /comparison of RubyUnits::Unit with (nil failed|NilClass)/) }
+      specify { expect(Unit("1 m")).to be < Unit("2 m") }
+      specify { expect(Unit("2 m")).to be > Unit("1 m") }
+      specify { expect(Unit("1 m")).to be < Unit("1 mi") }
+      specify { expect(Unit("2 m")).to be > Unit("1 ft") }
+      specify { expect(Unit("70 tempF")).to be > Unit("10 degC") }
+      specify { expect(Unit("1 m")).to be > 0 }
+      specify { expect { expect(Unit("1 m")).not_to be > nil }.to raise_error(ArgumentError, /comparison of RubyUnits::Unit with (nil failed|NilClass)/) }
     end
 
     context "incompatible units cannot be compared" do
@@ -897,11 +897,11 @@ end
 describe "Unit Conversions" do
 
   context "between compatible units" do
-    specify { Unit("1 s").convert_to("ns").should == Unit("1e9 ns") }
-    specify { Unit("1 s").convert_to("ns").should == Unit("1e9 ns") }
-    specify { (Unit("1 s") >> "ns").should == Unit("1e9 ns") }
+    specify { expect(Unit("1 s").convert_to("ns")).to eq(Unit("1e9 ns")) }
+    specify { expect(Unit("1 s").convert_to("ns")).to eq(Unit("1e9 ns")) }
+    specify { expect(Unit("1 s") >> "ns").to eq(Unit("1e9 ns")) }
 
-    specify { Unit("1 m").convert_to(Unit("ft")).should be_within(Unit("0.001 ft")).of(Unit("3.28084 ft")) }
+    specify { expect(Unit("1 m").convert_to(Unit("ft"))).to be_within(Unit("0.001 ft")).of(Unit("3.28084 ft")) }
   end
 
   context "between incompatible units" do
@@ -917,34 +917,34 @@ describe "Unit Conversions" do
     # note that 'temp' units are for temperature readings on a scale, while 'deg' units are used to represent
     # differences between temperatures, offsets, or other differential temperatures.
 
-    specify { Unit("100 tempC").should be_within(Unit("0.001 degK")).of(Unit("373.15 tempK")) }
-    specify { Unit("0 tempC").should be_within(Unit("0.001 degK")).of(Unit("273.15 tempK")) }
-    specify { Unit("37 tempC").should be_within(Unit("0.01 degK")).of(Unit("310.15 tempK")) }
-    specify { Unit("-273.15 tempC").should == Unit("0 tempK") }
+    specify { expect(Unit("100 tempC")).to be_within(Unit("0.001 degK")).of(Unit("373.15 tempK")) }
+    specify { expect(Unit("0 tempC")).to be_within(Unit("0.001 degK")).of(Unit("273.15 tempK")) }
+    specify { expect(Unit("37 tempC")).to be_within(Unit("0.01 degK")).of(Unit("310.15 tempK")) }
+    specify { expect(Unit("-273.15 tempC")).to eq(Unit("0 tempK")) }
 
-    specify { Unit("212 tempF").should be_within(Unit("0.001 degK")).of(Unit("373.15 tempK")) }
-    specify { Unit("32 tempF").should be_within(Unit("0.001 degK")).of(Unit("273.15 tempK")) }
-    specify { Unit("98.6 tempF").should be_within(Unit("0.01 degK")).of(Unit("310.15 tempK")) }
-    specify { Unit("-459.67 tempF").should == Unit("0 tempK") }
+    specify { expect(Unit("212 tempF")).to be_within(Unit("0.001 degK")).of(Unit("373.15 tempK")) }
+    specify { expect(Unit("32 tempF")).to be_within(Unit("0.001 degK")).of(Unit("273.15 tempK")) }
+    specify { expect(Unit("98.6 tempF")).to be_within(Unit("0.01 degK")).of(Unit("310.15 tempK")) }
+    specify { expect(Unit("-459.67 tempF")).to eq(Unit("0 tempK")) }
 
-    specify { Unit("671.67 tempR").should be_within(Unit("0.001 degK")).of(Unit("373.15 tempK")) }
-    specify { Unit("491.67 tempR").should be_within(Unit("0.001 degK")).of(Unit("273.15 tempK")) }
-    specify { Unit("558.27 tempR").should be_within(Unit("0.01 degK")).of(Unit("310.15 tempK")) }
-    specify { Unit("0 tempR").should == Unit("0 tempK") }
+    specify { expect(Unit("671.67 tempR")).to be_within(Unit("0.001 degK")).of(Unit("373.15 tempK")) }
+    specify { expect(Unit("491.67 tempR")).to be_within(Unit("0.001 degK")).of(Unit("273.15 tempK")) }
+    specify { expect(Unit("558.27 tempR")).to be_within(Unit("0.01 degK")).of(Unit("310.15 tempK")) }
+    specify { expect(Unit("0 tempR")).to eq(Unit("0 tempK")) }
 
-    specify { Unit("100 tempK").convert_to("tempC").should be_within(U "0.01 degC").of(Unit("-173.15 tempC")) }
-    specify { Unit("100 tempK").convert_to("tempF").should be_within(U "0.01 degF").of(Unit("-279.67 tempF")) }
-    specify { Unit("100 tempK").convert_to("tempR").should be_within(U "0.01 degR").of(Unit("180 tempR")) }
+    specify { expect(Unit("100 tempK").convert_to("tempC")).to be_within(U "0.01 degC").of(Unit("-173.15 tempC")) }
+    specify { expect(Unit("100 tempK").convert_to("tempF")).to be_within(U "0.01 degF").of(Unit("-279.67 tempF")) }
+    specify { expect(Unit("100 tempK").convert_to("tempR")).to be_within(U "0.01 degR").of(Unit("180 tempR")) }
 
-    specify { Unit("1 degC").should == Unit("1 degK") }
-    specify { Unit("1 degF").should == Unit("1 degR") }
-    specify { Unit("1 degC").should == Unit("1.8 degR") }
-    specify { Unit("1 degF").should be_within(Unit("0.001 degK")).of(Unit("0.5555 degK")) }
+    specify { expect(Unit("1 degC")).to eq(Unit("1 degK")) }
+    specify { expect(Unit("1 degF")).to eq(Unit("1 degR")) }
+    specify { expect(Unit("1 degC")).to eq(Unit("1.8 degR")) }
+    specify { expect(Unit("1 degF")).to be_within(Unit("0.001 degK")).of(Unit("0.5555 degK")) }
   end
 
   context "reported bugs" do
-    specify { (Unit("189 Mtonne") * Unit("1189 g/tonne")).should == Unit("224721 tonne") }
-    specify { (Unit("189 Mtonne") * Unit("1189 g/tonne")).convert_to("tonne").should == Unit("224721 tonne") }
+    specify { expect(Unit("189 Mtonne") * Unit("1189 g/tonne")).to eq(Unit("224721 tonne")) }
+    specify { expect((Unit("189 Mtonne") * Unit("1189 g/tonne")).convert_to("tonne")).to eq(Unit("224721 tonne")) }
   end
 
   describe "Foot-inch conversions" do
@@ -958,8 +958,8 @@ describe "Unit Conversions" do
         ["88 in", %Q{7'4"}],
         ["89 in", %Q{7'5"}]
     ].each do |inches, feet|
-      specify { Unit(inches).convert_to("ft").should == Unit(feet) }
-      specify { Unit(inches).to_s(:ft).should == feet }
+      specify { expect(Unit(inches).convert_to("ft")).to eq(Unit(feet)) }
+      specify { expect(Unit(inches).to_s(:ft)).to eq(feet) }
     end
   end
 
@@ -974,8 +974,8 @@ describe "Unit Conversions" do
         ["88 oz", "5 lbs, 8 oz"],
         ["89 oz", "5 lbs, 9 oz"]
     ].each do |ounces, pounds|
-      specify { Unit(ounces).convert_to("lbs").should == Unit(pounds) }
-      specify { Unit(ounces).to_s(:lbs).should == pounds }
+      specify { expect(Unit(ounces).convert_to("lbs")).to eq(Unit(pounds)) }
+      specify { expect(Unit(ounces).to_s(:lbs)).to eq(pounds) }
     end
   end
 end
@@ -984,13 +984,13 @@ describe "Unit Math" do
   context "operators:" do
     context "addition (+)" do
       context "between compatible units" do
-        specify { (Unit("0 m") + Unit("10 m")).should == Unit("10 m") }
-        specify { (Unit("5 kg") + Unit("10 kg")).should == Unit("15 kg") }
+        specify { expect(Unit("0 m") + Unit("10 m")).to eq(Unit("10 m")) }
+        specify { expect(Unit("5 kg") + Unit("10 kg")).to eq(Unit("15 kg")) }
       end
 
       context "between a zero unit and another unit" do
-        specify { (Unit("0 kg") + Unit("10 m")).should == Unit("10 m") }
-        specify { (Unit("0 m") + Unit("10 kg")).should == Unit("10 kg") }
+        specify { expect(Unit("0 kg") + Unit("10 m")).to eq(Unit("10 m")) }
+        specify { expect(Unit("0 m") + Unit("10 kg")).to eq(Unit("10 kg")) }
       end
 
       context "between incompatible units" do
@@ -1005,8 +1005,8 @@ describe "Unit Math" do
       end
 
       context "between a unit and coerceable types" do
-        specify { (Unit('10 kg') + %w{1 kg}).should == Unit('11 kg') }
-        specify { (Unit('10 kg') + "1 kg").should == Unit('11 kg') }
+        specify { expect(Unit('10 kg') + %w{1 kg}).to eq(Unit('11 kg')) }
+        specify { expect(Unit('10 kg') + "1 kg").to eq(Unit('11 kg')) }
       end
 
       context "between two temperatures" do
@@ -1014,24 +1014,24 @@ describe "Unit Math" do
       end
 
       context "between a temperature and a degree" do
-        specify { (Unit("100 tempK") + Unit("100 degK")).should == Unit("200 tempK") }
+        specify { expect(Unit("100 tempK") + Unit("100 degK")).to eq(Unit("200 tempK")) }
       end
 
       context "between a degree and a temperature" do
-        specify { (Unit("100 degK") + Unit("100 tempK")).should == Unit("200 tempK") }
+        specify { expect(Unit("100 degK") + Unit("100 tempK")).to eq(Unit("200 tempK")) }
       end
 
     end
 
     context "subtracting (-)" do
       context "compatible units" do
-        specify { (Unit("0 m") - Unit("10 m")).should == Unit("-10 m") }
-        specify { (Unit("5 kg") - Unit("10 kg")).should == Unit("-5 kg") }
+        specify { expect(Unit("0 m") - Unit("10 m")).to eq(Unit("-10 m")) }
+        specify { expect(Unit("5 kg") - Unit("10 kg")).to eq(Unit("-5 kg")) }
       end
 
       context "a unit from a zero unit" do
-        specify { (Unit("0 kg") - Unit("10 m")).should == Unit("-10 m") }
-        specify { (Unit("0 m") - Unit("10 kg")).should == Unit("-10 kg") }
+        specify { expect(Unit("0 kg") - Unit("10 m")).to eq(Unit("-10 m")) }
+        specify { expect(Unit("0 m") - Unit("10 kg")).to eq(Unit("-10 kg")) }
       end
 
       context "incompatible units" do
@@ -1041,8 +1041,8 @@ describe "Unit Math" do
       end
 
       context "between a unit and coerceable types" do
-        specify { (Unit('10 kg') - %w{1 kg}).should == Unit('9 kg') }
-        specify { (Unit('10 kg') - "1 kg").should == Unit('9 kg') }
+        specify { expect(Unit('10 kg') - %w{1 kg}).to eq(Unit('9 kg')) }
+        specify { expect(Unit('10 kg') - "1 kg").to eq(Unit('9 kg')) }
       end
 
       context "a number from a unit" do
@@ -1051,11 +1051,11 @@ describe "Unit Math" do
       end
 
       context "between two temperatures" do
-        specify { (Unit("100 tempK") - Unit("100 tempK")).should == Unit("0 degK") }
+        specify { expect(Unit("100 tempK") - Unit("100 tempK")).to eq(Unit("0 degK")) }
       end
 
       context "between a temperature and a degree" do
-        specify { (Unit("100 tempK") - Unit("100 degK")).should == Unit("0 tempK") }
+        specify { expect(Unit("100 tempK") - Unit("100 degK")).to eq(Unit("0 tempK")) }
       end
 
       context "between a degree and a temperature" do
@@ -1066,19 +1066,19 @@ describe "Unit Math" do
 
     context "multiplying (*)" do
       context "between compatible units" do
-        specify { (Unit("0 m") * Unit("10 m")).should == Unit("0 m^2") }
-        specify { (Unit("5 kg") * Unit("10 kg")).should == Unit("50 kg^2") }
+        specify { expect(Unit("0 m") * Unit("10 m")).to eq(Unit("0 m^2")) }
+        specify { expect(Unit("5 kg") * Unit("10 kg")).to eq(Unit("50 kg^2")) }
       end
 
       context "between incompatible units" do
-        specify { (Unit("0 m") * Unit("10 kg")).should == Unit("0 kg*m") }
-        specify { (Unit("5 m") * Unit("10 kg")).should == Unit("50 kg*m") }
+        specify { expect(Unit("0 m") * Unit("10 kg")).to eq(Unit("0 kg*m")) }
+        specify { expect(Unit("5 m") * Unit("10 kg")).to eq(Unit("50 kg*m")) }
         specify { expect { Unit("10 m") * nil }.to raise_error(ArgumentError) }
       end
 
       context "between a unit and coerceable types" do
-        specify { (Unit('10 kg') * %w{1 kg}).should == Unit('10 kg^2') }
-        specify { (Unit('10 kg') * "1 kg").should == Unit('10 kg^2') }
+        specify { expect(Unit('10 kg') * %w{1 kg}).to eq(Unit('10 kg^2')) }
+        specify { expect(Unit('10 kg') * "1 kg").to eq(Unit('10 kg^2')) }
       end
 
       context "by a temperature" do
@@ -1086,27 +1086,27 @@ describe "Unit Math" do
       end
 
       context "by a number" do
-        specify { (10 * Unit("5 kg")).should == Unit("50 kg") }
+        specify { expect(10 * Unit("5 kg")).to eq(Unit("50 kg")) }
       end
 
     end
 
     context "dividing (/)" do
       context "compatible units" do
-        specify { (Unit("0 m") / Unit("10 m")).should == Unit(0) }
-        specify { (Unit("5 kg") / Unit("10 kg")).should == Rational(1, 2) }
-        specify { (Unit("5 kg") / Unit("5 kg")).should == 1 }
+        specify { expect(Unit("0 m") / Unit("10 m")).to eq(Unit(0)) }
+        specify { expect(Unit("5 kg") / Unit("10 kg")).to eq(Rational(1, 2)) }
+        specify { expect(Unit("5 kg") / Unit("5 kg")).to eq(1) }
       end
 
       context "incompatible units" do
-        specify { (Unit("0 m") / Unit("10 kg")).should == Unit("0 m/kg") }
-        specify { (Unit("5 m") / Unit("10 kg")).should == Unit("1/2 m/kg") }
+        specify { expect(Unit("0 m") / Unit("10 kg")).to eq(Unit("0 m/kg")) }
+        specify { expect(Unit("5 m") / Unit("10 kg")).to eq(Unit("1/2 m/kg")) }
         specify { expect { Unit("10 m") / nil }.to raise_error(ArgumentError) }
       end
 
       context "between a unit and coerceable types" do
-        specify { (Unit('10 kg^2') / %w{1 kg}).should == Unit('10 kg') }
-        specify { (Unit('10 kg^2') / "1 kg").should == Unit('10 kg') }
+        specify { expect(Unit('10 kg^2') / %w{1 kg}).to eq(Unit('10 kg')) }
+        specify { expect(Unit('10 kg^2') / "1 kg").to eq(Unit('10 kg')) }
       end
 
       context "by a temperature" do
@@ -1114,11 +1114,11 @@ describe "Unit Math" do
       end
 
       context "a number by a unit" do
-        specify { (10 / Unit("5 kg")).should == Unit("2 1/kg") }
+        specify { expect(10 / Unit("5 kg")).to eq(Unit("2 1/kg")) }
       end
 
       context "a unit by a number" do
-        specify { (Unit("5 kg") / 2).should == Unit("2.5 kg") }
+        specify { expect(Unit("5 kg") / 2).to eq(Unit("2.5 kg")) }
       end
 
       context "by zero" do
@@ -1135,16 +1135,16 @@ describe "Unit Math" do
       end
 
       context Unit("0 m") do
-        it { (subject**1).should == subject }
-        it { (subject**2).should == subject }
+        it { expect(subject**1).to eq(subject) }
+        it { expect(subject**2).to eq(subject) }
       end
 
       context Unit("1 m") do
-        it { (subject**0).should == 1 }
-        it { (subject**1).should == subject }
-        it { (subject**(-1)).should == 1/subject }
-        it { (subject**(2)).should == Unit("1 m^2") }
-        it { (subject**(-2)).should == Unit("1 1/m^2") }
+        it { expect(subject**0).to eq(1) }
+        it { expect(subject**1).to eq(subject) }
+        it { expect(subject**(-1)).to eq(1/subject) }
+        it { expect(subject**(2)).to eq(Unit("1 m^2")) }
+        it { expect(subject**(-2)).to eq(Unit("1 1/m^2")) }
         specify { expect { subject**(1/2) }.to raise_error(ArgumentError, "Illegal root") }
         # because 1 m^(1/2) doesn't make any sense
         specify { expect { subject**(Complex(1, 1)) }.to raise_error(ArgumentError, "exponentiation of complex numbers is not yet supported.") }
@@ -1152,8 +1152,8 @@ describe "Unit Math" do
       end
 
       context Unit("1 m^2") do
-        it { (subject**(Rational(1, 2))).should == Unit("1 m") }
-        it { (subject**(0.5)).should == Unit("1 m") }
+        it { expect(subject**(Rational(1, 2))).to eq(Unit("1 m")) }
+        it { expect(subject**(0.5)).to eq(Unit("1 m")) }
 
         specify { expect { subject**(0.12345) }.to raise_error(ArgumentError, "Not a n-th root (1..9), use 1/n") }
         specify { expect { subject**("abcdefg") }.to raise_error(ArgumentError, "Invalid Exponent") }
@@ -1163,8 +1163,8 @@ describe "Unit Math" do
 
     context "modulo (%)" do
       context "compatible units" do
-        specify { (Unit("2 m") % Unit("1 m")).should == 0 }
-        specify { (Unit("5 m") % Unit("2 m")).should == 1 }
+        specify { expect(Unit("2 m") % Unit("1 m")).to eq(0) }
+        specify { expect(Unit("5 m") % Unit("2 m")).to eq(1) }
       end
 
       specify "incompatible units raises an exception" do
@@ -1173,11 +1173,11 @@ describe "Unit Math" do
     end
 
     context "unary negation (-)" do
-      specify { (-Unit("1 mm")).should == Unit("-1 mm") }
+      specify { expect(-Unit("1 mm")).to eq(Unit("-1 mm")) }
     end
 
     context "unary plus (+)" do
-      specify { (+Unit('1 mm')).should == Unit('1 mm') }
+      specify { expect(+Unit('1 mm')).to eq(Unit('1 mm')) }
     end
   end
 
@@ -1196,10 +1196,10 @@ describe "Unit Math" do
       expect { Unit("100 tempC").power(2) }.to raise_error(ArgumentError, "Cannot raise a temperature to a power")
     end
 
-    specify { (subject.power(-1)).should == Unit("1 1/m") }
-    specify { (subject.power(0)).should == 1 }
-    specify { (subject.power(1)).should == subject }
-    specify { (subject.power(2)).should == Unit("1 m^2") }
+    specify { expect(subject.power(-1)).to eq(Unit("1 1/m")) }
+    specify { expect(subject.power(0)).to eq(1) }
+    specify { expect(subject.power(1)).to eq(subject) }
+    specify { expect(subject.power(2)).to eq(Unit("1 m^2")) }
 
   end
 
@@ -1218,30 +1218,30 @@ describe "Unit Math" do
       expect { Unit("100 tempC").root(2) }.to raise_error(ArgumentError, "Cannot take the root of a temperature")
     end
 
-    specify { (Unit("1 m^2").root(-2)).should == Unit("1 1/m") }
-    specify { (subject.root(-1)).should == Unit("1 1/m") }
+    specify { expect(Unit("1 m^2").root(-2)).to eq(Unit("1 1/m")) }
+    specify { expect(subject.root(-1)).to eq(Unit("1 1/m")) }
     specify { expect { (subject.root(0)) }.to raise_error(ArgumentError, "0th root undefined") }
-    specify { (subject.root(1)).should == subject }
-    specify { (Unit("1 m^2").root(2)).should == Unit("1 m") }
+    specify { expect(subject.root(1)).to eq(subject) }
+    specify { expect(Unit("1 m^2").root(2)).to eq(Unit("1 m")) }
 
   end
 
   context "#inverse" do
-    specify { Unit("1 m").inverse.should == Unit("1 1/m") }
+    specify { expect(Unit("1 m").inverse).to eq(Unit("1 1/m")) }
     specify { expect { Unit("100 tempK").inverse }.to raise_error(ArgumentError, "Cannot divide with temperatures") }
   end
 
   context "convert to scalars" do
-    specify { Unit("10").to_i.should be_kind_of(Integer) }
+    specify { expect(Unit("10").to_i).to be_kind_of(Integer) }
     specify { expect { Unit("10 m").to_i }.to raise_error(RuntimeError, "Cannot convert '10 m' to Integer unless unitless.  Use Unit#scalar") }
 
-    specify { Unit("10.0").to_f.should be_kind_of(Float) }
+    specify { expect(Unit("10.0").to_f).to be_kind_of(Float) }
     specify { expect { Unit("10.0 m").to_f }.to raise_error(RuntimeError, "Cannot convert '10 m' to Float unless unitless.  Use Unit#scalar") }
 
-    specify { Unit("1+1i").to_c.should be_kind_of(Complex) }
+    specify { expect(Unit("1+1i").to_c).to be_kind_of(Complex) }
     specify { expect { Unit("1+1i m").to_c }.to raise_error(RuntimeError, "Cannot convert '1.0+1.0i m' to Complex unless unitless.  Use Unit#scalar") }
 
-    specify { Unit("3/7").to_r.should be_kind_of(Rational) }
+    specify { expect(Unit("3/7").to_r).to be_kind_of(Rational) }
     specify { expect { Unit("3/7 m").to_r }.to raise_error(RuntimeError, "Cannot convert '3/7 m' to Rational unless unitless.  Use Unit#scalar") }
 
   end
@@ -1249,13 +1249,13 @@ describe "Unit Math" do
   context "absolute value (#abs)" do
     context "of a unitless unit" do
       specify "returns the absolute value of the scalar" do
-        Unit("-10").abs.should == 10
+        expect(Unit("-10").abs).to eq(10)
       end
     end
 
     context "of a unit" do
       specify "returns a unit with the absolute value of the scalar" do
-        Unit("-10 m").abs.should == Unit("10 m")
+        expect(Unit("-10 m").abs).to eq(Unit("10 m"))
       end
     end
   end
@@ -1263,13 +1263,13 @@ describe "Unit Math" do
   context "#ceil" do
     context "of a unitless unit" do
       specify "returns the ceil of the scalar" do
-        Unit("10.1").ceil.should == 11
+        expect(Unit("10.1").ceil).to eq(11)
       end
     end
 
     context "of a unit" do
       specify "returns a unit with the ceil of the scalar" do
-        Unit("10.1 m").ceil.should == Unit("11 m")
+        expect(Unit("10.1 m").ceil).to eq(Unit("11 m"))
       end
     end
   end
@@ -1277,13 +1277,13 @@ describe "Unit Math" do
   context "#floor" do
     context "of a unitless unit" do
       specify "returns the floor of the scalar" do
-        Unit("10.1").floor.should == 10
+        expect(Unit("10.1").floor).to eq(10)
       end
     end
 
     context "of a unit" do
       specify "returns a unit with the floor of the scalar" do
-        Unit("10.1 m").floor.should == Unit("10 m")
+        expect(Unit("10.1 m").floor).to eq(Unit("10 m"))
       end
     end
   end
@@ -1291,13 +1291,13 @@ describe "Unit Math" do
   context "#round" do
     context "of a unitless unit" do
       specify "returns the round of the scalar" do
-        Unit("10.5").round.should == 11
+        expect(Unit("10.5").round).to eq(11)
       end
     end
 
     context "of a unit" do
       specify "returns a unit with the round of the scalar" do
-        Unit("10.5 m").round.should == Unit("11 m")
+        expect(Unit("10.5 m").round).to eq(Unit("11 m"))
       end
     end
   end
@@ -1305,109 +1305,109 @@ describe "Unit Math" do
   context "#truncate" do
     context "of a unitless unit" do
       specify "returns the truncate of the scalar" do
-        Unit("10.5").truncate.should == 10
+        expect(Unit("10.5").truncate).to eq(10)
       end
     end
 
     context "of a unit" do
       specify "returns a unit with the truncate of the scalar" do
-        Unit("10.5 m").truncate.should == Unit("10 m")
+        expect(Unit("10.5 m").truncate).to eq(Unit("10 m"))
       end
     end
 
     context "of a complex unit" do
       specify "returns a unit with the truncate of the scalar" do
-        Unit("10.5 kg*m/s^3").truncate.should == Unit("10 kg*m/s^3")
+        expect(Unit("10.5 kg*m/s^3").truncate).to eq(Unit("10 kg*m/s^3"))
       end
     end
   end
 
   context '#zero?' do
     it "is true when the scalar is zero on the base scale" do
-      Unit("0").should be_zero
-      Unit("0 mm").should be_zero
-      Unit("-273.15 tempC").should be_zero
+      expect(Unit("0")).to be_zero
+      expect(Unit("0 mm")).to be_zero
+      expect(Unit("-273.15 tempC")).to be_zero
     end
 
     it "is false when the scalar is not zero" do
-      Unit("1").should_not be_zero
-      Unit("1 mm").should_not be_zero
-      Unit("0 tempC").should_not be_zero
+      expect(Unit("1")).not_to be_zero
+      expect(Unit("1 mm")).not_to be_zero
+      expect(Unit("0 tempC")).not_to be_zero
     end
   end
 
   context '#succ' do
-    specify { Unit("1").succ.should == Unit("2") }
-    specify { Unit("1 mm").succ.should == Unit("2 mm") }
-    specify { Unit("1 mm").next.should == Unit("2 mm") }
-    specify { Unit("-1 mm").succ.should == Unit("0 mm") }
+    specify { expect(Unit("1").succ).to eq(Unit("2")) }
+    specify { expect(Unit("1 mm").succ).to eq(Unit("2 mm")) }
+    specify { expect(Unit("1 mm").next).to eq(Unit("2 mm")) }
+    specify { expect(Unit("-1 mm").succ).to eq(Unit("0 mm")) }
     specify { expect { Unit("1.5 mm").succ }.to raise_error(ArgumentError, "Non Integer Scalar") }
   end
 
   context '#pred' do
-    specify { Unit("1").pred.should == Unit("0") }
-    specify { Unit("1 mm").pred.should == Unit("0 mm") }
-    specify { Unit("-1 mm").pred.should == Unit("-2 mm") }
+    specify { expect(Unit("1").pred).to eq(Unit("0")) }
+    specify { expect(Unit("1 mm").pred).to eq(Unit("0 mm")) }
+    specify { expect(Unit("-1 mm").pred).to eq(Unit("-2 mm")) }
     specify { expect { Unit("1.5 mm").pred }.to raise_error(ArgumentError, "Non Integer Scalar") }
   end
 
   context '#divmod' do
-    specify { Unit("5 mm").divmod(Unit("2 mm")).should == [2, 1] }
-    specify { Unit("1 km").divmod(Unit("2 m")).should == [500, 0] }
+    specify { expect(Unit("5 mm").divmod(Unit("2 mm"))).to eq([2, 1]) }
+    specify { expect(Unit("1 km").divmod(Unit("2 m"))).to eq([500, 0]) }
     specify { expect { Unit('1 m').divmod(Unit('2 kg')) }.to raise_error(ArgumentError, "Incompatible Units ('1 m' not compatible with '2 kg')") }
   end
 
   context '#div' do
-    specify { Unit('23 m').div(Unit('2 m')).should == 11 }
+    specify { expect(Unit('23 m').div(Unit('2 m'))).to eq(11) }
   end
 
   context '#best_prefix' do
-    specify { Unit('1024 KiB').best_prefix.should == Unit('1 MiB') }
-    specify { Unit('1000 m').best_prefix.should == Unit('1 km') }
+    specify { expect(Unit('1024 KiB').best_prefix).to eq(Unit('1 MiB')) }
+    specify { expect(Unit('1000 m').best_prefix).to eq(Unit('1 km')) }
     specify { expect { Unit('0 m').best_prefix }.to_not raise_error }
   end
 
   context "Time helper functions" do
     before do
-      Time.stub(:now).and_return(Time.utc(2011, 10, 16))
-      DateTime.stub(:now).and_return(DateTime.civil(2011, 10, 16))
-      Date.stub(:today).and_return(Date.civil(2011, 10, 16))
+      allow(Time).to receive(:now).and_return(Time.utc(2011, 10, 16))
+      allow(DateTime).to receive(:now).and_return(DateTime.civil(2011, 10, 16))
+      allow(Date).to receive(:today).and_return(Date.civil(2011, 10, 16))
     end
 
     context '#since' do
-      specify { Unit("min").since(Time.utc(2001, 4, 1, 0, 0, 0)).should == Unit("5544000 min") }
-      specify { Unit("min").since(DateTime.civil(2001, 4, 1, 0, 0, 0)).should == Unit("5544000 min") }
-      specify { Unit("min").since(Date.civil(2001, 4, 1)).should == Unit("5544000 min") }
+      specify { expect(Unit("min").since(Time.utc(2001, 4, 1, 0, 0, 0))).to eq(Unit("5544000 min")) }
+      specify { expect(Unit("min").since(DateTime.civil(2001, 4, 1, 0, 0, 0))).to eq(Unit("5544000 min")) }
+      specify { expect(Unit("min").since(Date.civil(2001, 4, 1))).to eq(Unit("5544000 min")) }
       specify { expect { Unit("min").since("4-1-2001") }.to raise_error(ArgumentError, "Must specify a Time, Date, or DateTime") }
       specify { expect { Unit("min").since(nil) }.to raise_error(ArgumentError, "Must specify a Time, Date, or DateTime") }
     end
 
     context '#before' do
-      specify { Unit("5 min").before(Time.now).should == Time.utc(2011, 10, 15, 23, 55) }
-      specify { Unit("5 min").before(DateTime.now).should == DateTime.civil(2011, 10, 15, 23, 55) }
-      specify { Unit("5 min").before(Date.today).should == DateTime.civil(2011, 10, 15, 23, 55) }
+      specify { expect(Unit("5 min").before(Time.now)).to eq(Time.utc(2011, 10, 15, 23, 55)) }
+      specify { expect(Unit("5 min").before(DateTime.now)).to eq(DateTime.civil(2011, 10, 15, 23, 55)) }
+      specify { expect(Unit("5 min").before(Date.today)).to eq(DateTime.civil(2011, 10, 15, 23, 55)) }
       specify { expect { Unit('5 min').before(nil) }.to raise_error(ArgumentError, "Must specify a Time, Date, or DateTime") }
       specify { expect { Unit('5 min').before("12:00") }.to raise_error(ArgumentError, "Must specify a Time, Date, or DateTime") }
     end
 
     context '#ago' do
-      specify { Unit("5 min").ago.should be_kind_of Time }
-      specify { Unit("10000 y").ago.should be_kind_of Time }
-      specify { Unit("1 year").ago.should == Time.utc(2010, 10, 16) }
+      specify { expect(Unit("5 min").ago).to be_kind_of Time }
+      specify { expect(Unit("10000 y").ago).to be_kind_of Time }
+      specify { expect(Unit("1 year").ago).to eq(Time.utc(2010, 10, 16)) }
     end
 
     context '#until' do
-      specify { Unit("min").until(Date.civil(2011, 10, 17)).should == Unit("1440 min") }
-      specify { Unit("min").until(DateTime.civil(2011, 10, 21)).should == Unit("7200 min") }
-      specify { Unit("min").until(Time.utc(2011, 10, 21)).should == Unit("7200 min") }
+      specify { expect(Unit("min").until(Date.civil(2011, 10, 17))).to eq(Unit("1440 min")) }
+      specify { expect(Unit("min").until(DateTime.civil(2011, 10, 21))).to eq(Unit("7200 min")) }
+      specify { expect(Unit("min").until(Time.utc(2011, 10, 21))).to eq(Unit("7200 min")) }
       specify { expect { Unit('5 min').until(nil) }.to raise_error(ArgumentError, "Must specify a Time, Date, or DateTime") }
       specify { expect { Unit('5 min').until("12:00") }.to raise_error(ArgumentError, "Must specify a Time, Date, or DateTime") }
     end
 
     context '#from' do
-      specify { Unit("1 day").from(Date.civil(2011, 10, 17)).should == Date.civil(2011, 10, 18) }
-      specify { Unit("5 min").from(DateTime.civil(2011, 10, 21)).should == DateTime.civil(2011, 10, 21, 00, 05) }
-      specify { Unit("5 min").from(Time.utc(2011, 10, 21)).should == Time.utc(2011, 10, 21, 00, 05) }
+      specify { expect(Unit("1 day").from(Date.civil(2011, 10, 17))).to eq(Date.civil(2011, 10, 18)) }
+      specify { expect(Unit("5 min").from(DateTime.civil(2011, 10, 21))).to eq(DateTime.civil(2011, 10, 21, 00, 05)) }
+      specify { expect(Unit("5 min").from(Time.utc(2011, 10, 21))).to eq(Time.utc(2011, 10, 21, 00, 05)) }
       specify { expect { Unit('5 min').from(nil) }.to raise_error(ArgumentError, "Must specify a Time, Date, or DateTime") }
       specify { expect { Unit('5 min').from("12:00") }.to raise_error(ArgumentError, "Must specify a Time, Date, or DateTime") }
     end
@@ -1418,11 +1418,11 @@ end
 
 describe "Unit Output formatting" do
   context Unit("10.5 m/s^2") do
-    specify { subject.to_s.should == "10.5 m/s^2" }
-    specify { subject.to_s("%0.2f").should == "10.50 m/s^2" }
-    specify { subject.to_s("%0.2e km/s^2").should == "1.05e-02 km/s^2" }
-    specify { subject.to_s("km/s^2").should == "0.0105 km/s^2" }
-    specify { subject.to_s(STDOUT).should == "10.5 m/s^2" }
+    specify { expect(subject.to_s).to eq("10.5 m/s^2") }
+    specify { expect(subject.to_s("%0.2f")).to eq("10.50 m/s^2") }
+    specify { expect(subject.to_s("%0.2e km/s^2")).to eq("1.05e-02 km/s^2") }
+    specify { expect(subject.to_s("km/s^2")).to eq("0.0105 km/s^2") }
+    specify { expect(subject.to_s(STDOUT)).to eq("10.5 m/s^2") }
     specify { expect { subject.to_s("random string") }.to raise_error(ArgumentError, "'random' Unit not recognized") }
   end
 
@@ -1441,7 +1441,7 @@ describe "Unit Output formatting" do
 
     subject { Unit("8 cups") }
 
-    specify { subject.to_s.should == "8 cupz" }
+    specify { expect(subject.to_s).to eq("8 cupz") }
 
   end
 
@@ -1453,6 +1453,6 @@ describe "Equations with Units" do
     let(:v) { Unit('1 m^3') }
     let(:n) { Unit("1 mole") }
     let(:r) { Unit("8.31451 J/mol*degK") }
-    specify { ((p*v)/(n*r)).convert_to('tempK').should be_within(Unit("0.1 degK")).of(Unit("12027.2 tempK")) }
+    specify { expect(((p*v)/(n*r)).convert_to('tempK')).to be_within(Unit("0.1 degK")).of(Unit("12027.2 tempK")) }
   end
 end

--- a/spec/ruby-units/utf-8/unit_spec.rb
+++ b/spec/ruby-units/utf-8/unit_spec.rb
@@ -7,17 +7,17 @@ if RUBY_VERSION.include?('1.9')
     context 'when the UTF-8 symbol is used' do
       context 'Angles' do
         it 'should be a degree' do
-          Unit("180\u00B0").units.should == 'deg'
+          expect(Unit("180\u00B0").units).to eq('deg')
         end
       end
 
       context 'Temperature' do
         it 'should be a degree Celcius' do
-          Unit("180\u00B0C").units.should == 'degC'
+          expect(Unit("180\u00B0C").units).to eq('degC')
         end
 
         it 'should be a degree Fahrenheit' do
-          Unit("180\u00B0F").units.should == 'degF'
+          expect(Unit("180\u00B0F").units).to eq('degF')
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ require 'rubygems'
 require 'bundler'
 Bundler.setup(:development)
 require 'rspec/core'
+require 'rspec/its'
 
 # Initiate code coverage generation when needed
 begin


### PR DESCRIPTION
This conversion is done by Transpec 2.3.7 with the following command:
    transpec

* 281 conversions
    from: obj.should
      to: expect(obj).to

* 172 conversions
    from: == expected
      to: eq(expected)

* 136 conversions
    from: it { should_not ... }
      to: it { is_expected.not_to ... }

* 90 conversions
    from: it { should ... }
      to: it { is_expected.to ... }

* 22 conversions
    from: obj.should_not
      to: expect(obj).not_to

* 7 conversions
    from: === expected
      to: be === expected

* 7 conversions
    from: > expected
      to: be > expected

* 5 conversions
    from: < expected
      to: be < expected

* 4 conversions
    from: obj.stub(:message)
      to: allow(obj).to receive(:message)

* 3 conversions
    from: =~ /pattern/
      to: match(/pattern/)

For more details: https://github.com/yujinakayama/transpec#supported-conversions