### PR TITLE
Load RubyUnits::Unit instead of Date::Unit when overriding core

### DIFF
--- a/lib/ruby_units/date.rb
+++ b/lib/ruby_units/date.rb
@@ -8,7 +8,7 @@ class Date
   # @return [Unit]
   def +(unit)
     case unit
-    when Unit
+    when RubyUnits::Unit
       unit = unit.convert_to('d').round if ['y', 'decade', 'century'].include? unit.units 
       unit_date_add(unit.convert_to('day').scalar)
     else
@@ -21,7 +21,7 @@ class Date
   # @return [Unit]
   def -(unit)
     case unit
-    when Unit 
+    when RubyUnits::Unit 
       unit = unit.convert_to('d').round if ['y', 'decade', 'century'].include? unit.units 
       unit_date_sub(unit.convert_to('day').scalar)
     else
@@ -34,7 +34,7 @@ class Date
   # @return (see Unit#initialize)
   # @param [Object] other convert to same units as passed
   def to_unit(other = nil)
-    other ? Unit.new(self).convert_to(other) : Unit.new(self)
+    other ? RubyUnits::Unit.new(self).convert_to(other) : RubyUnits::Unit.new(self)
   end
   alias :unit :to_unit
   


### PR DESCRIPTION
This fixes "uninitialized constant `Date::Unit`" error.