### PR TITLE
Fixes for Singular Unit Parsing

### DIFF
--- a/lib/ruby_units/unit.rb
+++ b/lib/ruby_units/unit.rb
@@ -44,9 +44,11 @@ module RubyUnits
     @@UNIT_MATCH_REGEX = nil
     UNITY              = '<1>'
     UNITY_ARRAY        = [UNITY]
-    FEET_INCH_REGEX    = /(\d+)\s*(?:'|ft|feet)\s*(\d+)\s*(?:"|in|inch(?:es)?)/
+    FEET_INCH_UNITS_REGEX = /(?:'|ft|feet)\s*(\d+)\s*(?:"|in|inch(?:es)?)/
+    FEET_INCH_REGEX    = /(\d+)\s*#{FEET_INCH_UNITS_REGEX}/
     TIME_REGEX         = /(\d+)*:(\d+)*:*(\d+)*[:,]*(\d+)*/
-    LBS_OZ_REGEX       = /(\d+)\s*(?:#|lbs?|pounds?|pound-mass)+[\s,]*(\d+)\s*(?:oz|ounces?)/
+    LBS_OZ_UNITS_REGEX = /(?:#|lbs?|pounds?|pound-mass)+[\s,]*(\d+)\s*(?:oz|ounces?)/
+    LBS_OZ_REGEX       = /(\d+)\s*#{LBS_OZ_UNITS_REGEX}/
     SCI_NUMBER         = %r{([+-]?\d*[.]?\d+(?:[Ee][+-]?)?\d*)}
     RATIONAL_NUMBER    = /\(?([+-])?(\d+[ -])?(\d+)\/(\d+)\)?/
     COMPLEX_NUMBER     = /#{SCI_NUMBER}?#{SCI_NUMBER}i\b/
@@ -374,7 +376,7 @@ module RubyUnits
       unary_unit = self.units || ""
       if options.first.instance_of?(String)
         opt_scalar, opt_units = RubyUnits::Unit.parse_into_numbers_and_units(options[0])
-        unless @@cached_units.keys.include?(opt_units) || (opt_units =~ /(#{RubyUnits::Unit.temp_regex})|(pounds?|lbs?[ ,]\d+ ounces?|oz)|('\d+")|(ft|feet[ ,]\d+ in|inch|inch(?:es))|%|(#{TIME_REGEX})|i\s?(.+)?|&plusmn;|\+\/-/)
+        unless @@cached_units.keys.include?(opt_units) || (opt_units =~ /(#{RubyUnits::Unit.temp_regex})|(#{LBS_OZ_UNITS_REGEX})|#{FEET_INCH_UNITS_REGEX}|%|(#{TIME_REGEX})|i\s?(.+)?|&plusmn;|\+\/-/)
           @@cached_units[opt_units] = (self.scalar == 1 ? self : opt_units.unit) if opt_units && !opt_units.empty?
         end
       end

--- a/lib/ruby_units/unit.rb
+++ b/lib/ruby_units/unit.rb
@@ -44,9 +44,9 @@ module RubyUnits
     @@UNIT_MATCH_REGEX = nil
     UNITY              = '<1>'
     UNITY_ARRAY        = [UNITY]
-    FEET_INCH_REGEX    = /(\d+)\s*(?:'|ft|feet)\s*(\d+)\s*(?:"|in|inches)/
+    FEET_INCH_REGEX    = /(\d+)\s*(?:'|ft|feet)\s*(\d+)\s*(?:"|in|inch(?:es)?)/
     TIME_REGEX         = /(\d+)*:(\d+)*:*(\d+)*[:,]*(\d+)*/
-    LBS_OZ_REGEX       = /(\d+)\s*(?:#|lbs|pounds|pound-mass)+[\s,]*(\d+)\s*(?:oz|ounces)/
+    LBS_OZ_REGEX       = /(\d+)\s*(?:#|lbs?|pounds?|pound-mass)+[\s,]*(\d+)\s*(?:oz|ounces?)/
     SCI_NUMBER         = %r{([+-]?\d*[.]?\d+(?:[Ee][+-]?)?\d*)}
     RATIONAL_NUMBER    = /\(?([+-])?(\d+[ -])?(\d+)\/(\d+)\)?/
     COMPLEX_NUMBER     = /#{SCI_NUMBER}?#{SCI_NUMBER}i\b/
@@ -374,7 +374,7 @@ module RubyUnits
       unary_unit = self.units || ""
       if options.first.instance_of?(String)
         opt_scalar, opt_units = RubyUnits::Unit.parse_into_numbers_and_units(options[0])
-        unless @@cached_units.keys.include?(opt_units) || (opt_units =~ /(#{RubyUnits::Unit.temp_regex})|(pounds|lbs[ ,]\d+ ounces|oz)|('\d+")|(ft|feet[ ,]\d+ in|inch|inches)|%|(#{TIME_REGEX})|i\s?(.+)?|&plusmn;|\+\/-/)
+        unless @@cached_units.keys.include?(opt_units) || (opt_units =~ /(#{RubyUnits::Unit.temp_regex})|(pounds?|lbs?[ ,]\d+ ounces?|oz)|('\d+")|(ft|feet[ ,]\d+ in|inch|inch(?:es))|%|(#{TIME_REGEX})|i\s?(.+)?|&plusmn;|\+\/-/)
           @@cached_units[opt_units] = (self.scalar == 1 ? self : opt_units.unit) if opt_units && !opt_units.empty?
         end
       end

--- a/spec/ruby-units/unit_spec.rb
+++ b/spec/ruby-units/unit_spec.rb
@@ -203,7 +203,7 @@ describe "Create some simple units" do
   end
 
   # feet/in form
-  ["5 feet 6 inches", "5 feet 6 inch", "5ft 6in", "5 ft 6 in"].each do |unit|
+  ["5 feet 6 inches", "5 feet 6 inch", "5ft 6in", "5 ft 6 in", %(5'6"), %(5' 6")].each do |unit|
     describe Unit(unit) do
       it { should be_an_instance_of Unit }
       its(:scalar) { should == 5.5 }

--- a/spec/ruby-units/unit_spec.rb
+++ b/spec/ruby-units/unit_spec.rb
@@ -203,33 +203,37 @@ describe "Create some simple units" do
   end
 
   # feet/in form
-  describe Unit("5ft 6in") do
-    it { should be_an_instance_of Unit }
-    its(:scalar) { should == 5.5 }
-    its(:units) { should == "ft" }
-    its(:kind) { should == :length }
-    it { should_not be_temperature }
-    it { should_not be_degree }
-    it { should_not be_base }
-    it { should_not be_unitless }
-    it { should_not be_zero }
-    its(:base) { should be_within(Unit("0.01 m")).of Unit("1.6764 m") }
-    specify { subject.to_s(:ft).should == %{5'6"} }
+  ["5 feet 6 inches", "5 feet 6 inch", "5ft 6in", "5 ft 6 in"].each do |unit|
+    describe Unit(unit) do
+      it { should be_an_instance_of Unit }
+      its(:scalar) { should == 5.5 }
+      its(:units) { should == "ft" }
+      its(:kind) { should == :length }
+      it { should_not be_temperature }
+      it { should_not be_degree }
+      it { should_not be_base }
+      it { should_not be_unitless }
+      it { should_not be_zero }
+      its(:base) { should be_within(Unit("0.01 m")).of Unit("1.6764 m") }
+      specify { subject.to_s(:ft).should == %{5'6"} }
+    end
   end
 
   # pound/ounces form
-  describe Unit("6lbs 5oz") do
-    it { should be_an_instance_of Unit }
-    its(:scalar) { should be_within(0.001).of 6.312 }
-    its(:units) { should == "lbs" }
-    its(:kind) { should == :mass }
-    it { should_not be_temperature }
-    it { should_not be_degree }
-    it { should_not be_base }
-    it { should_not be_unitless }
-    it { should_not be_zero }
-    its(:base) { should be_within(Unit("0.01 kg")).of Unit("2.8633 kg") }
-    specify { subject.to_s(:lbs).should == "6 lbs, 5 oz" }
+  ["6 pounds 5 ounces", "6 pound 5 ounce", "6lbs 5oz", "6 lbs 5 oz", "6lb 5oz", "6 lb 5 oz"].each do |unit|
+    describe Unit(unit) do
+      it { should be_an_instance_of Unit }
+      its(:scalar) { should be_within(0.001).of 6.312 }
+      its(:units) { should == "lbs" }
+      its(:kind) { should == :mass }
+      it { should_not be_temperature }
+      it { should_not be_degree }
+      it { should_not be_base }
+      it { should_not be_unitless }
+      it { should_not be_zero }
+      its(:base) { should be_within(Unit("0.01 kg")).of Unit("2.8633 kg") }
+      specify { subject.to_s(:lbs).should == "6 lbs, 5 oz" }
+    end
   end
 
   # temperature


### PR DESCRIPTION
This is in reference to #117. 

Note that the second commit is the result of me attempting to fix #117 by modifying `LBS_OZ_REGEX` and `FEET_INCH_REGEX` and then things still not working. Further investigation revealed the cause to be the regex duplication.

Your regexes I put in `*_UNITS_REGEX` are more flexible then what was replaced in the 2nd commit (for example the addition of `"pound-mass"` and the ability to now match `6' 5"`), though I think some additional work needs to be done RE: #122 . Let me know what you think and I can make additional adjustments.
