### PR TITLE
Convert specs to RSpec 3.3.2 syntax with Transpec

### DIFF
--- a/spec/ruby-units/unit_spec.rb
+++ b/spec/ruby-units/unit_spec.rb
@@ -817,7 +817,7 @@ describe "Create some simple units" do
 
   # rational scalar with numeric modified unit
   describe Unit.new('12.0mg/6.0mL') do
-    it { should be_an_instance_of Unit }
+    it { is_expected.to be_an_instance_of Unit }
 
     describe '#scalar' do
       subject { super().scalar }


### PR DESCRIPTION
This conversion is done by Transpec 3.1.1 with the following command:
    transpec

* 1 conversion
    from: it { should ... }
      to: it { is_expected.to ... }

For more details: https://github.com/yujinakayama/transpec#supported-conversions