### PR TITLE
Support for stone units

### DIFF
--- a/lib/ruby_units/unit.rb
+++ b/lib/ruby_units/unit.rb
@@ -41,6 +41,10 @@ module RubyUnits
     # defined at the point in the code where we need this regex.
     LBS_OZ_UNIT_REGEX  = /(?:#|lbs?|pounds?|pound-mass)+[\s,]*(\d+)\s*(?:ozs?|ounces?)/
     LBS_OZ_REGEX       = /(\d+)\s*#{LBS_OZ_UNIT_REGEX}/
+    # ideally we would like to generate this regex from the alias for a 'stone' and 'pound', but they aren't
+    # defined at the point in the code where we need this regex.
+    STONE_UNIT_REGEX   = /(\d+)\s*(?:sts?|stones?)+/
+    STONE_LB_REGEX     = /#{STONE_UNIT_REGEX}\s*(\d*)/
     TIME_REGEX         = /(\d+)*:(\d+)*:*(\d+)*[:,]*(\d+)*/
     SCI_NUMBER         = %r{([+-]?\d*[.]?\d+(?:[Ee][+-]?)?\d*)}
     RATIONAL_NUMBER    = /\(?([+-])?(\d+[ -])?(\d+)\/(\d+)\)?/

--- a/lib/ruby_units/unit_definitions/standard.rb
+++ b/lib/ruby_units/unit_definitions/standard.rb
@@ -147,9 +147,9 @@ RubyUnits::Unit.define('carat') do |carat|
   carat.aliases    = %w{ct carat carats}
 end
 
-RubyUnits::Unit.define('stone') do |carat|
-  carat.definition = RubyUnits::Unit.new('14 lbs')
-  carat.aliases    = %{st stone}
+RubyUnits::Unit.define('stone') do |stone|
+  stone.definition = RubyUnits::Unit.new('14 lbs')
+  stone.aliases    = %w{st stone}
 end
 
 # time

--- a/lib/ruby_units/unit_definitions/standard.rb
+++ b/lib/ruby_units/unit_definitions/standard.rb
@@ -148,7 +148,7 @@ RubyUnits::Unit.define('carat') do |carat|
 end
 
 RubyUnits::Unit.define('stone') do |stone|
-  stone.definition = RubyUnits::Unit.new('14 lbs')
+  stone.definition = RubyUnits::Unit.new('635029/100000 kg')
   stone.aliases    = %w{st stone}
 end
 

--- a/lib/ruby_units/unit_definitions/standard.rb
+++ b/lib/ruby_units/unit_definitions/standard.rb
@@ -147,6 +147,11 @@ RubyUnits::Unit.define('carat') do |carat|
   carat.aliases    = %w{ct carat carats}
 end
 
+RubyUnits::Unit.define('stone') do |carat|
+  carat.definition = RubyUnits::Unit.new('14 lbs')
+  carat.aliases    = %{st stone}
+end
+
 # time
 
 RubyUnits::Unit.define('minute') do |min|


### PR DESCRIPTION
Added support for stone units based on the information at [http://www.disabled-world.com/calculators-charts/convert-stones.php](http://www.disabled-world.com/calculators-charts/convert-stones.php).

Stones work much like feet or pounds and ounces, with a variety of inputs:
- 3 st = 3 stone
- 3 st 4 = 3 stone, 4 pounds
- 3 st 4 lbs = 3 stone, 4 pounds

I've tested these and similar inputs, and they all work. I'm new to GitHub, Ruby, and contributing to OSS, so if I'm missing any steps or you need to me to do anything else, don't hesitate to let me know how I can help you add support for stones.
