### PR TITLE
Feature/separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ Unit.new('1.5 mm').to_s("%0.2f")  # "1.50 mm".  Enter any valid format
 Unit.new('1.5 mm').to_s("in")     # converts to inches before printing
 Unit.new("2 m").to_s(:ft)         # returns 6'7"
 Unit.new("100 kg").to_s(:lbs)     # returns 220 lbs, 7 oz
+Unit.new("1 kg").to_s(separator: '')      # returns 1kg
+Unit.new("1 kg").to_s("g", separator: '') # returns 1000g
 ```
 
 Time Helpers

--- a/README.md
+++ b/README.md
@@ -113,11 +113,11 @@ Units will display themselves nicely based on the display_name for the units and
 The to_s also accepts some options.
 
 ```
-Unit.new('1.5 mm').to_s("%0.2f")  # "1.50 mm".  Enter any valid format
-                                    string.  Also accepts strftime format
-Unit.new('1.5 mm').to_s("in")     # converts to inches before printing
-Unit.new("2 m").to_s(:ft)         # returns 6'7"
-Unit.new("100 kg").to_s(:lbs)     # returns 220 lbs, 7 oz
+Unit.new('1.5 mm').to_s("%0.2f")          # "1.50 mm".  Enter any valid format
+                                            string.  Also accepts strftime format
+Unit.new('1.5 mm').to_s("in")             # converts to inches before printing
+Unit.new("2 m").to_s(:ft)                 # returns 6'7"
+Unit.new("100 kg").to_s(:lbs)             # returns 220 lbs, 7 oz
 Unit.new("1 kg").to_s(separator: '')      # returns 1kg
 Unit.new("1 kg").to_s("g", separator: '') # returns 1000g
 ```

--- a/lib/ruby_units/unit.rb
+++ b/lib/ruby_units/unit.rb
@@ -482,7 +482,7 @@ module RubyUnits
     #
     # @param [Symbol] target_units
     # @return [String]
-    def to_s(target_units=nil)
+    def to_s(target_units=nil, separator: ' ')
       out = @output[target_units]
       if out
         return out
@@ -516,9 +516,9 @@ module RubyUnits
         else
           out = case @scalar
                 when Rational, Complex
-                  "#{@scalar} #{self.units}"
+                  "#{@scalar}#{separator}#{self.units}"
                 else
-                  "#{'%g' % @scalar} #{self.units}"
+                  "#{'%g' % @scalar}#{separator}#{self.units}"
                 end.strip
         end
         @output[target_units] = out

--- a/spec/ruby-units/unit_spec.rb
+++ b/spec/ruby-units/unit_spec.rb
@@ -2157,6 +2157,15 @@ describe "Unit Output formatting" do
 
   end
 
+  context 'when using a custom separator' do
+    subject { Unit.new('10 mg') }
+    specify { expect(subject.to_s).to eq('10 mg') }
+    specify { expect(subject.to_s(separator: '')).to eq('10mg') }
+    specify { expect(subject.to_s(separator: ':')).to eq('10:mg') }
+    specify { expect(Unit.new('1/3 g').to_s(separator: '')).to eq('1/3g') }
+    specify { expect(Unit.new('0.5 g').to_s(separator: '')).to eq('0.5g') }
+  end
+
 end
 
 describe "Equations with Units" do


### PR DESCRIPTION
This allows users to remove or change the separator between the scalar and the units without resorting to string manipulation after the fact. Written because a project I am working on has a lot of places where they want to show weights as `123g` or `456mg`.
