### PR TITLE
Add encoding to prefix definitions

### DIFF
--- a/lib/ruby_units/unit_definitions/prefix.rb
+++ b/lib/ruby_units/unit_definitions/prefix.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 
 {
   'googol' => [%w{googol},             1e100],


### PR DESCRIPTION
The `µ` character in lib/ruby_units/unit_definitions/prefix.rb causes this problem in my app when the file is required:

```
invalid multibyte char (US-ASCII) (SyntaxError)
```

This fixes it.