### PR TITLE
Feature/fix issue 126

### DIFF
--- a/lib/ruby_units/unit.rb
+++ b/lib/ruby_units/unit.rb
@@ -1237,6 +1237,17 @@ module RubyUnits
       self.to(RubyUnits::Unit.new(@@PREFIX_MAP.key(_best_prefix)+self.units(false)))
     end
 
+    # override hash method so objects with same values are considered equal
+    def hash
+      [@scalar,
+      @numerator,
+      @denominator,
+      @is_base,
+      @signature,
+      @base_scalar,
+      @unit_name].hash
+    end
+
     # Protected and Private Functions that should only be called from this class
     protected
 

--- a/spec/ruby-units/unit_spec.rb
+++ b/spec/ruby-units/unit_spec.rb
@@ -2168,3 +2168,23 @@ describe "Equations with Units" do
     specify { expect(((p*v)/(n*r)).convert_to('tempK')).to be_within(RubyUnits::Unit.new('0.1 degK')).of(RubyUnits::Unit.new('12027.2 tempK')) }
   end
 end
+
+describe "Unit hash method" do
+  context "should return equal values for identical units" do
+    let(:kg_unit_1) { RubyUnits::Unit.new("2.2 kg") }
+    let(:kg_unit_2) { RubyUnits::Unit.new("2.2 kg") }
+
+    specify { expect(kg_unit_1).to eq(kg_unit_2) }
+    specify { expect(kg_unit_1.hash).to eq(kg_unit_2.hash) }
+    specify { expect([kg_unit_1, kg_unit_2].uniq.size).to eq(1) }
+  end
+
+  context "should return not equal values for differnet units" do
+    let(:kg_unit) { RubyUnits::Unit.new("2.2 kg") }
+    let(:lb_unit) { RubyUnits::Unit.new("2.2 lbs") }
+
+    specify { expect(kg_unit).to_not eq(lb_unit) }
+    specify { expect(kg_unit.hash).to_not eq(lb_unit.hash) }
+    specify { expect([kg_unit, lb_unit].uniq.size).to eq(2) }
+  end
+end


### PR DESCRIPTION
Overrides base hash method to ensure units with the same values return the same hash value.
Fixes issue #126 
