### PR TITLE
Add lbr as an aliase for pounds

### DIFF
--- a/lib/ruby_units/unit_definitions/standard.rb
+++ b/lib/ruby_units/unit_definitions/standard.rb
@@ -122,7 +122,7 @@ end
 # calculations
 RubyUnits::Unit.define('pound') do |pound|
   pound.definition = RubyUnits::Unit.new(Rational(45_359_237, 1e8), 'kg')
-  pound.aliases    = %w(lbs lb lbm pound-mass pound pounds #)
+  pound.aliases    = %w(lbs lb lbm lbr pound-mass pound pounds #)
 end
 
 RubyUnits::Unit.define('ounce') do |ounce|

--- a/spec/ruby_units/configuration_spec.rb
+++ b/spec/ruby_units/configuration_spec.rb
@@ -20,6 +20,7 @@ describe RubyUnits::Configuration do
       expect(RubyUnits::Unit.new('1 m').to_s).to eq '1m'
       expect(RubyUnits::Unit.new('14.5 lbs').to_s(:lbs)).to eq '14lbs, 8oz'
       expect(RubyUnits::Unit.new('220 lbs').to_s(:stone)).to eq '15stone, 10lb'
+      expect(RubyUnits::Unit.new('14.5 lbr').to_s(:lbs)).to eq '14lbs, 8oz'
       expect(RubyUnits::Unit.new('14.2 ft').to_s(:ft)).to eq %(14'2")
       expect(RubyUnits::Unit.new('1/2 cup').to_s).to eq '1/2cu'
       expect(RubyUnits::Unit.new('123.55 lbs').to_s('%0.2f')).to eq '123.55lbs'


### PR DESCRIPTION
In the industry I work in, lbr is commonly used for pounds and the UNECE.org recognizes it as an abbreviation for pounds. 

http://www.unece.org/fileadmin/DAM/cefact/recommendations/add3lmdt.htm