### PR TITLE
Fix temperature converting rational issue

### DIFF
--- a/lib/ruby_units/unit.rb
+++ b/lib/ruby_units/unit.rb
@@ -1104,19 +1104,19 @@ module RubyUnits
                          when '<tempK>'
                            @scalar
                          when '<tempF>'
-                           (@scalar + 459.67) * Rational(5, 9)
+                           (@scalar + 459.67).to_r * Rational(5, 9)
                          when '<tempR>'
-                           @scalar * Rational(5, 9)
+                           @scalar.to_r * Rational(5, 9)
                          end
         q = case @@unit_map[target_unit]
             when '<tempC>'
-              @base_scalar - 273.15
+              @base_scalar - 273.15r
             when '<tempK>'
               @base_scalar
             when '<tempF>'
-              @base_scalar * Rational(9, 5) - 459.67
+              @base_scalar.to_r * Rational(9, 5) - 459.67r
             when '<tempR>'
-              @base_scalar * Rational(9, 5)
+              @base_scalar.to_r * Rational(9, 5)
             end
         return RubyUnits::Unit.new("#{q} #{target_unit}")
       else

--- a/spec/ruby_units/temperature_spec.rb
+++ b/spec/ruby_units/temperature_spec.rb
@@ -104,6 +104,8 @@ describe 'temperatures' do
       specify { expect(RubyUnits::Unit.new('100 tK').convert_to('tempC')).to be_within(RubyUnits::Unit.new('0.01 degC')).of(RubyUnits::Unit.new('-173.15 tempC')) }
       specify { expect(RubyUnits::Unit.new('100 tK').convert_to('tempF')).to be_within(RubyUnits::Unit.new('0.01 degF')).of(RubyUnits::Unit.new('-279.67 tempF')) }
       specify { expect(RubyUnits::Unit.new('100 tK').convert_to('tempR')).to be_within(RubyUnits::Unit.new('0.01 degR')).of(RubyUnits::Unit.new('180 tempR')) }
+
+      specify { expect(RubyUnits::Unit.new('32 tF').convert_to('tempC')).to eq(RubyUnits::Unit.new('0 tC')) }
     end
   end
 end


### PR DESCRIPTION
Converting temperatures involves mathematical calculations on rational numbers, however both of the inputs have to be fractions in order for the result to be a fraction, and to avoid rounding errors

```
2.4.1 > Unit.new("32 tempF").convert_to("tempC")
=> 5.68434e-14 tempC
```