### PR TITLE
Fix unitless addition and subtraction.

### DIFF
--- a/lib/ruby_units/unit.rb
+++ b/lib/ruby_units/unit.rb
@@ -847,7 +847,7 @@ module RubyUnits
               RubyUnits::Unit.new(scalar: (other.scalar + convert_to(other.temperature_scale).scalar), numerator: other.numerator, denominator: other.denominator, signature: other.signature)
             end
           else
-            RubyUnits::Unit.new(scalar: (base_scalar + other.base_scalar), numerator: base.numerator, denominator: base.denominator, signature: @signature).to(units)
+            RubyUnits::Unit.new(scalar: (base_scalar + other.base_scalar), numerator: base.numerator, denominator: base.denominator, signature: @signature).convert_to(self)
           end
         else
           raise ArgumentError, "Incompatible Units ('#{self}' not compatible with '#{other}')"
@@ -883,7 +883,7 @@ module RubyUnits
           elsif other.temperature?
             raise ArgumentError, 'Cannot subtract a temperature from a differential degree unit'
           else
-            RubyUnits::Unit.new(scalar: (base_scalar - other.base_scalar), numerator: base.numerator, denominator: base.denominator, signature: @signature).to(units)
+            RubyUnits::Unit.new(scalar: (base_scalar - other.base_scalar), numerator: base.numerator, denominator: base.denominator, signature: @signature).convert_to(self)
           end
         else
           raise ArgumentError, "Incompatible Units ('#{self}' not compatible with '#{other}')"

--- a/spec/ruby_units/unit_spec.rb
+++ b/spec/ruby_units/unit_spec.rb
@@ -1744,6 +1744,10 @@ describe 'Unit Math' do
       context 'between a degree and a temperature' do
         specify { expect(RubyUnits::Unit.new('100 degK') + RubyUnits::Unit.new('100 tempK')).to eq(RubyUnits::Unit.new('200 tempK')) }
       end
+
+      context 'between two unitless units' do
+        specify { expect(RubyUnits::Unit.new('1') + RubyUnits::Unit.new('2')).to eq 3 }
+      end
     end
 
     context 'subtracting (-)' do
@@ -1783,6 +1787,10 @@ describe 'Unit Math' do
 
       context 'between a degree and a temperature' do
         specify { expect { (RubyUnits::Unit.new('100 degK') - RubyUnits::Unit.new('100 tempK')) }.to raise_error(ArgumentError, 'Cannot subtract a temperature from a differential degree unit') }
+      end
+
+      context 'a unitless unit from another unitless unit' do
+        specify { expect(RubyUnits::Unit.new('1') - RubyUnits::Unit.new('2')).to eq -1 }
       end
     end
 


### PR DESCRIPTION
When adding or subtracting two unitless numbers, the result used to be 
converted to the same units as the receiver.  This didn't work if the 
receiver was unitless.  The fix changes the way we do the conversion in 
a way that is not subject to this problem.

Fixes #174