### PR TITLE
Ruby 2.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: ruby
 rvm:
+  - 2.6
   - 2.5
   - 2.4
   - 2.3


### PR DESCRIPTION
Adds Ruby 2.6 to the travis test matrix - no changes are needed to support the new ruby version!

