### PR TITLE
Add support for <unit> per N <unit>

### DIFF
--- a/lib/ruby_units/unit.rb
+++ b/lib/ruby_units/unit.rb
@@ -1511,7 +1511,8 @@ module RubyUnits
         return
       end
 
-      if defined?(Rational) && unit_string =~ RATIONAL_NUMBER
+      power_match = %r{\^\d+/\d+} # This prevents thinking e.g. kg^2/100l is rational because of 2/100
+      if defined?(Rational) && unit_string =~ RATIONAL_NUMBER && !unit_string.match(power_match)
         sign, proper, numerator, denominator, unit_s = unit_string.scan(RATIONAL_REGEX)[0]
         sign = sign == '-' ? -1 : 1
         rational = sign * (proper.to_i + Rational(numerator.to_i, denominator.to_i))
@@ -1594,7 +1595,7 @@ module RubyUnits
       if bottom
         bottom.gsub!(BOTTOM_REGEX) { "#{Regexp.last_match(1)} " * Regexp.last_match(2).to_i }
         # Separate leading decimal from denominator, if any
-        bottom_scalar, bottom = bottom.scan(NUMBER_UNIT_REGEX)[0]
+        bottom_scalar, bottom = bottom.scan(NUMBER_UNIT_REGEX)[0] unless self.class.defined?(bottom) # Maintain scalar if it's part of the unit definition
       end
 
       @scalar = @scalar.to_f unless @scalar.nil? || @scalar.empty?

--- a/spec/ruby_units/unit_spec.rb
+++ b/spec/ruby_units/unit_spec.rb
@@ -861,6 +861,94 @@ describe 'Create some simple units' do
     end
   end
 
+  describe 'Units with rates of <unit> per N <unit>' do
+    subject { Unit.new(2, 'kg/100kg') }
+
+    before do
+      Unit.clear_cache # Needed for the following definition to consistently work
+      Unit.define('100kg') do |u|
+        u.definition = Unit.new('100 kg')
+        u.aliases = %w[100kg]
+      end
+    end
+
+    it { is_expected.to be_an_instance_of Unit }
+
+    describe '#scalar' do
+      subject { super().scalar }
+      it { is_expected.to be_an Numeric }
+      it { is_expected.to eq(2) }
+    end
+
+    describe '#units' do
+      subject { super().units }
+      it { is_expected.to be_a String }
+      it { is_expected.to eq('kg/100kg') }
+    end
+
+    context 'when there is a power involved (e.g. liters squared)' do
+      subject { Unit.new(2, 'l^2/100kg') }
+
+      it { is_expected.to be_an_instance_of Unit }
+
+      describe '#scalar' do
+        subject { super().scalar }
+        it { is_expected.to be_an Numeric }
+        it { is_expected.to eq(2) }
+      end
+
+      describe '#units' do
+        subject { super().units }
+        it { is_expected.to be_a String }
+        it { is_expected.to eq('l^2/100kg') }
+      end
+    end
+
+    describe 'Calculations' do
+      describe 'Addition' do
+        subject { Unit.new(2, 'kg/100kg') + Unit.new(2, 'kg/100kg') }
+
+        describe '#scalar', skip: 'TODO: Fix the 4/1 here' do
+          subject { super().scalar }
+          it { is_expected.to eq('4') }
+        end
+
+        describe '#units' do
+          subject { super().units }
+          it { is_expected.to eq('kg/100kg') }
+        end
+      end
+
+      describe 'Multiplication' do
+        subject { Unit.new(2, 'kg/100kg') * Unit.new(2, 'kg/100kg') }
+
+        describe '#scalar', skip: 'TODO: Fix the infinite loop here' do
+          subject { super().scalar }
+          it { is_expected.to eq('4') }
+        end
+
+        describe '#units', skip: 'TODO: Fix the infinite loop here' do
+          subject { super().units }
+          it { is_expected.to eq('kg/100kg') }
+        end
+      end
+
+      describe 'Division' do
+        subject { Unit.new(4, 'kg/100kg') / Unit.new(2, 'kg/100kg') }
+
+        describe '#scalar' do
+          subject { super().scalar }
+          it { is_expected.to eq(2) }
+        end
+
+        describe '#units' do
+          subject { super().units }
+          it { is_expected.to eq('') }
+        end
+      end
+    end
+  end
+
   # time string
   describe RubyUnits::Unit.new('1:23:45,200') do
     it { is_expected.to be_an_instance_of Unit }


### PR DESCRIPTION
E.g. "2 kg/100kg" or "4 l/1000l".

It's similar to a percentage, but can be for any scalar number, and is often the terminology used in industry, rather than percentages. E.g. in Agriculture - adding 4 liters of Roundup per 100 liters of tank mixture.

