### PR TITLE
Complex comparisons work differently in Ruby 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: ruby
 cache: bundler
 dist: xenial
 rvm:
+  - 2.7
   - 2.6
   - 2.5
   - 2.4

--- a/spec/ruby_units/complex_spec.rb
+++ b/spec/ruby_units/complex_spec.rb
@@ -1,14 +1,17 @@
 require File.dirname(__FILE__) + '/../spec_helper'
 
-# Complex numbers are a bit strange
-# Technically you can't really compare them using <=>, and ruby 1.9 does not implement this method for them
-# so it stands to reason that complex units should also not support :> or :<
-
 describe Complex do
   subject { Complex(1, 1) }
   it { is_expected.to respond_to :to_unit }
 end
 
+# Complex numbers are a bit strange. Technically you can't really compare them
+# using :<=>, and Ruby < 2.7 does not implement this method for them so it stands
+# to reason that complex units should also not support :> or :<.
+#
+# This inconsistency was corrected in Ruby 2.7.
+# @see https://rubyreferences.github.io/rubychanges/2.7.html#complex
+# @see https://bugs.ruby-lang.org/issues/15857
 describe 'Complex Unit' do
   subject { Complex(1.0, -1.0).to_unit }
 
@@ -19,7 +22,12 @@ describe 'Complex Unit' do
   it { is_expected.to be === '1-1i'.to_unit }
 
   it 'is not comparable' do
-    expect { subject > '1+1i'.to_unit }.to raise_error(NoMethodError)
-    expect { subject < '1+1i'.to_unit }.to raise_error(NoMethodError)
+    if Complex.respond_to?(:<=>) # this is true for Ruby >= 2.7
+      expect { subject > '1+1i'.to_unit }.to raise_error(ArgumentError)
+      expect { subject < '1+1i'.to_unit }.to raise_error(ArgumentError)
+    else
+      expect { subject > '1+1i'.to_unit }.to raise_error(NoMethodError)
+      expect { subject < '1+1i'.to_unit }.to raise_error(NoMethodError)
+    end
   end
 end

--- a/spec/ruby_units/complex_spec.rb
+++ b/spec/ruby_units/complex_spec.rb
@@ -22,7 +22,7 @@ describe 'Complex Unit' do
   it { is_expected.to be === '1-1i'.to_unit }
 
   it 'is not comparable' do
-    if Complex.respond_to?(:<=>) # this is true for Ruby >= 2.7
+    if subject.scalar.respond_to?(:<=>) # this is true for Ruby >= 2.7
       expect { subject > '1+1i'.to_unit }.to raise_error(ArgumentError)
       expect { subject < '1+1i'.to_unit }.to raise_error(ArgumentError)
     else


### PR DESCRIPTION
Fixes #213

This just changes the expectations in the tests to conform to what actually happens when used with Ruby 2.7.