### PR TITLE
Improve documentation and argument passing for `round`, `truncate`, `ceil` and `floor`

### DIFF
--- a/lib/ruby_units/unit.rb
+++ b/lib/ruby_units/unit.rb
@@ -1273,27 +1273,40 @@ module RubyUnits
 
     # ceil of a unit
     # @return [Numeric,Unit]
-    def ceil
-      return @scalar.ceil if unitless?
-      self.class.new(@scalar.ceil, @numerator, @denominator)
+    def ceil(*args)
+      return @scalar.ceil(*args) if unitless?
+
+      self.class.new(@scalar.ceil(*args), @numerator, @denominator)
     end
 
     # @return [Numeric,Unit]
-    def floor
-      return @scalar.floor if unitless?
-      self.class.new(@scalar.floor, @numerator, @denominator)
+    def floor(*args)
+      return @scalar.floor(*args) if unitless?
+
+      self.class.new(@scalar.floor(*args), @numerator, @denominator)
     end
 
+    # Round the unit according to the rules of the scalar's class. Call this
+    # with the arguments appropriate for the scalar's class (e.g., Integer,
+    # Rational, etc..). Because unit conversions can often result in Rational
+    # scalars (to preserve precision), it may be advisable to use +to_s+ to
+    # format output instead of using +round+.
+    # @example
+    #   RubyUnits::Unit.new('21870 mm/min').convert_to('m/min').round(1) #=> 2187/100 m/min
+    #   RubyUnits::Unit.new('21870 mm/min').convert_to('m/min').to_s('%0.1f') #=> 21.9 m/min
+    #
     # @return [Numeric,Unit]
-    def round(ndigits = 0)
-      return @scalar.round(ndigits) if unitless?
-      self.class.new(@scalar.round(ndigits), @numerator, @denominator)
+    def round(*args)
+      return @scalar.round(*args) if unitless?
+
+      self.class.new(@scalar.round(*args), @numerator, @denominator)
     end
 
     # @return [Numeric, Unit]
-    def truncate
-      return @scalar.truncate if unitless?
-      self.class.new(@scalar.truncate, @numerator, @denominator)
+    def truncate(*args)
+      return @scalar.truncate(*args) if unitless?
+
+      self.class.new(@scalar.truncate(*args), @numerator, @denominator)
     end
 
     # returns next unit in a range.  '1 mm'.to_unit.succ #=> '2 mm'.to_unit

--- a/lib/ruby_units/unit.rb
+++ b/lib/ruby_units/unit.rb
@@ -1296,10 +1296,10 @@ module RubyUnits
     #   RubyUnits::Unit.new('21870 mm/min').convert_to('m/min').to_s('%0.1f') #=> 21.9 m/min
     #
     # @return [Numeric,Unit]
-    def round(*args)
-      return @scalar.round(*args) if unitless?
+    def round(*args, **kwargs)
+      return @scalar.round(*args, **kwargs) if unitless?
 
-      self.class.new(@scalar.round(*args), @numerator, @denominator)
+      self.class.new(@scalar.round(*args, **kwargs), @numerator, @denominator)
     end
 
     # @return [Numeric, Unit]

--- a/spec/ruby_units/unit_spec.rb
+++ b/spec/ruby_units/unit_spec.rb
@@ -2038,8 +2038,14 @@ describe 'Unit Math' do
     end
 
     context 'of a unit' do
-      specify 'returns a unit with the ceil of the scalar' do
-        expect(RubyUnits::Unit.new('10.1 m').ceil).to eq(RubyUnits::Unit.new('11 m'))
+      subject(:unit) { RubyUnits::Unit.new('1.2345 m') }
+
+      it 'returns a unit with the ceil of the scalar' do
+        expect(unit.ceil).to eq(RubyUnits::Unit.new('2 m'))
+      end
+
+      it 'forwards arguments to the scalar' do
+        expect(unit.ceil(2)).to eq(RubyUnits::Unit.new('1.24 m'))
       end
     end
   end
@@ -2052,8 +2058,14 @@ describe 'Unit Math' do
     end
 
     context 'of a unit' do
-      specify 'returns a unit with the floor of the scalar' do
-        expect(RubyUnits::Unit.new('10.1 m').floor).to eq(RubyUnits::Unit.new('10 m'))
+      subject(:unit) { RubyUnits::Unit.new('1.2345 m') }
+
+      it 'returns a unit with the floor of the scalar' do
+        expect(unit.floor).to eq(RubyUnits::Unit.new('1 m'))
+      end
+
+      it 'forwards arguments to the scalar' do
+        expect(unit.floor(2)).to eq(RubyUnits::Unit.new('1.23 m'))
       end
     end
   end
@@ -2066,8 +2078,14 @@ describe 'Unit Math' do
     end
 
     context 'of a unit' do
-      specify 'returns a unit with the round of the scalar' do
-        expect(RubyUnits::Unit.new('10.5 m').round).to eq(RubyUnits::Unit.new('11 m'))
+      subject(:unit) { RubyUnits::Unit.new('1.2345 m') }
+
+      it 'returns a unit with the round of the scalar' do
+        expect(unit.round).to eq(RubyUnits::Unit.new('1 m'))
+      end
+
+      it 'forwards arguments to the scalar' do
+        expect(unit.round(3, half: :down)).to eq(RubyUnits::Unit.new('1.234 m'))
       end
     end
   end
@@ -2080,8 +2098,14 @@ describe 'Unit Math' do
     end
 
     context 'of a unit' do
-      specify 'returns a unit with the truncate of the scalar' do
-        expect(RubyUnits::Unit.new('10.5 m').truncate).to eq(RubyUnits::Unit.new('10 m'))
+      subject(:unit) { RubyUnits::Unit.new('1.2345 m') }
+
+      it 'returns a unit with the truncate of the scalar' do
+        expect(unit.truncate).to eq(RubyUnits::Unit.new('1 m'))
+      end
+
+      it 'forwards arguments to the scalar' do
+        expect(unit.truncate(2)).to eq(RubyUnits::Unit.new('1.23 m'))
       end
     end
 

--- a/spec/ruby_units/unit_spec.rb
+++ b/spec/ruby_units/unit_spec.rb
@@ -2032,7 +2032,7 @@ describe 'Unit Math' do
 
   context '#ceil' do
     context 'of a unitless unit' do
-      specify 'returns the ceil of the scalar' do
+      it 'returns the ceil of the scalar' do
         expect(RubyUnits::Unit.new('10.1').ceil).to eq(11)
       end
     end


### PR DESCRIPTION
The signatures for these methods changed in Ruby 2.5 and now we just forward the arguments as passed.
Fixes #231