### PR TITLE
round/ceil/floor for centi prefix not working

### DIFF
--- a/lib/ruby_units/unit.rb
+++ b/lib/ruby_units/unit.rb
@@ -1640,8 +1640,11 @@ module RubyUnits
         return self
       end
 
-      while unit_string.gsub!(/(<#{self.class.unit_regex})><(#{self.class.unit_regex}>)/, '\1*\2')
-        # collapse <x><y><z> into <x*y*z>...
+      while unit_string.gsub!(/<(#{self.class.prefix_regex})><(#{self.class.unit_regex})>/, '<\1\2>')
+        # replace <prefix><unit> with <prefixunit>
+      end
+      while unit_string.gsub!(/<#{self.class.unit_match_regex}><#{self.class.unit_match_regex}>/, '<\1\2>*<\3\4>')
+        # collapse <prefixunit><prefixunit> into <prefixunit>*<prefixunit>...
       end
       # ... and then strip the remaining brackets for x*y*z
       unit_string.gsub!(/[<>]/, '')

--- a/spec/ruby_units/unit_spec.rb
+++ b/spec/ruby_units/unit_spec.rb
@@ -2170,6 +2170,14 @@ describe 'Unit Math' do
         expect(unit.round(3, half: :down)).to eq(RubyUnits::Unit.new('1.234 m'))
       end
     end
+
+    context 'with a unit containing a centi-prefix' do
+      subject(:unit) { RubyUnits::Unit.new('1.2345 cm^2') }
+
+      it 'rounds correctly for squared unit' do
+        expect(unit.round).to eq(RubyUnits::Unit.new('1 cm^2'))
+      end
+    end
   end
 
   context '#truncate' do


### PR DESCRIPTION
Fixes #343

The regex was incorrectly matching on `nt` (nucleotides) in `centi`.  Revised the algorithm to be more precise and properly account for prefixes.