### PR TITLE
Conflicting Unit abbreviations (M and P)

### DIFF
--- a/lib/ruby_units/unit_definitions/standard.rb
+++ b/lib/ruby_units/unit_definitions/standard.rb
@@ -27,7 +27,8 @@ end
 
 RubyUnits::Unit.define('naut-mile') do |naut|
   naut.definition = RubyUnits::Unit.new('1852 m')
-  naut.aliases    = %w[nmi M NM]
+  naut.aliases    = %w[nmi NM]
+  # Don't use the 'M' abbreviation here since it conflicts with 'Molar'
 end
 
 # on land
@@ -71,7 +72,9 @@ end
 
 RubyUnits::Unit.define('pica') do |pica|
   pica.definition = RubyUnits::Unit.new('1/72 ft')
-  pica.aliases    = %w[P pica picas]
+  pica.aliases    = %w[pica picas]
+  # Don't use 'P' as an abbreviation since it conflicts with 'Poise'
+  # Don't use 'pc' as an abbreviation since it conflicts with 'parsec'
 end
 
 RubyUnits::Unit.define('point') do |point|


### PR DESCRIPTION
Fixes #345

'M' is an abbreviation for 'Nautical Mile' which conflicts with 'Molar'
'P' is an abbreviation for 'Pica' which conflicts with 'Poise'

We remove these abbreviations in favor of the more common unit. If these are needed, it is possible to redefine them to include the required abbreviation.  If you do so, you will want to remove the existing abbreviations to avoid ambiguous unit matching.